### PR TITLE
Add test framework

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright 2018-2021, Intel Corporation
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 
 project(pmemstream C CXX)
 set(PMEMSTREAM_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ set(PKG_CONFIG_REQUIRES)
 set(DEB_DEPENDS)
 set(RPM_DEPENDS)
 
-set(TEST_DIR ${CMAKE_CURRENT_BINARY_DIR}/test CACHE STRING "working directory for tests")
+set(TEST_DIR ${CMAKE_CURRENT_BINARY_DIR}/tests CACHE STRING "working directory for tests")
 message(STATUS "TEST_DIR set to: \"${TEST_DIR}\"")
 
 # Do not treat include directories from the interfaces
@@ -69,7 +69,7 @@ set(CMAKE_NO_SYSTEM_FROM_IMPORTED 1)
 # ----------------------------------------------------------------- #
 # XXX: turn these ON, when appropriate sources added
 option(BUILD_EXAMPLES "build examples" ON)
-option(BUILD_TESTS "build tests" OFF)
+option(BUILD_TESTS "build tests" ON)
 option(BUILD_DOC "build documentation" OFF)
 
 option(USE_CCACHE "use ccache if it is available in the system" ON)
@@ -82,7 +82,8 @@ option(USE_ASAN "enable AddressSanitizer checks" OFF)
 option(USE_UBSAN "enable UndefinedBehaviorSanitizer checks" OFF)
 
 option(TESTS_USE_FORCED_PMEM "run tests with PMEM_IS_PMEM_FORCE=1 - it speeds up tests execution on emulated pmem" OFF)
-option(TESTS_USE_VALGRIND "enable tests with valgrind (fail build if Valgrind not found)" ON)
+# XXX: enable with valgrind support
+option(TESTS_USE_VALGRIND "enable tests with valgrind (fail build if Valgrind not found)" OFF)
 option(TESTS_PMREORDER "enable tests with pmreorder (if pmreorder found; it requires PMDK ver. >= 1.9)" OFF)
 option(TESTS_LONG "enable long running tests" OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,9 +67,9 @@ set(CMAKE_NO_SYSTEM_FROM_IMPORTED 1)
 # ----------------------------------------------------------------- #
 ## CMake build options
 # ----------------------------------------------------------------- #
-# XXX: turn these ON, when appropriate sources added
 option(BUILD_EXAMPLES "build examples" ON)
 option(BUILD_TESTS "build tests" ON)
+# XXX: turn these ON, when docs added
 option(BUILD_DOC "build documentation" OFF)
 
 option(USE_CCACHE "use ccache if it is available in the system" ON)
@@ -102,11 +102,14 @@ if(NOT WIN32)
 	find_package(PkgConfig QUIET)
 endif()
 
+# all our components require libpmem2
 if(PKG_CONFIG_FOUND)
 	pkg_check_modules(LIBPMEM2 REQUIRED libpmem2>=${LIBPMEM2_REQUIRED_VERSION})
 else()
 	find_package(LIBPMEM2 REQUIRED ${LIBPMEM2_REQUIRED_VERSION})
 endif()
+include_directories(${LIBPMEM2_INCLUDE_DIRS})
+link_directories(${LIBPMEM2_LIBRARY_DIRS})
 
 list(APPEND PKG_CONFIG_REQUIRES "libpmem2 >= ${LIBPMEM2_REQUIRED_VERSION}")
 list(APPEND RPM_DEPENDS "libpmem2 >= ${LIBPMEM2_REQUIRED_VERSION}")
@@ -137,6 +140,7 @@ add_common_flag(-Wsign-conversion)
 add_common_flag(-Wsign-compare)
 add_common_flag(-Wunreachable-code-return)
 add_common_flag(-Wunused-macros)
+add_common_flag(-Wno-maybe-uninitialized)
 add_common_flag(-fno-common)
 add_common_flag(-ggdb DEBUG)
 add_common_flag(-DDEBUG DEBUG)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@
 - [Adding new dependency](#adding-new-dependency)
 - [Extending Public API](#extending-public-api)
 - [Configuring GitHub fork](#configuring-github-fork)
+- [Debugging](#debugging)
 
 # Opening new issues
 
@@ -120,3 +121,17 @@ To enable automatic images pushing to GitHub Container Registry, following varia
   (with only read & write packages permissions), to be generated as described
   [here](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token#creating-a-token)
   for selected account (user defined in above variable).
+
+# Debugging
+
+Test framework supports debugging under gdb.
+
+* For remote debugging set `GDBSERVER` environment variable. Its content will be passed to gdbserver
+application as first positional argument, so it should define how gdbserver will communicate with gdb.
+Example usage with a single test:
+
+```sh
+GDBSERVER=localhost:4444 ctest -R vector_comp_operators_0_none --output-on-failure
+```
+
+* For local debugging in graphical environment using cgdb, set `CGDB` environment variable to `gnome-terminal` or `konsole` accordingly to your setup.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,17 +14,17 @@ set(SOURCES libpmemstream.c
 
 add_library(pmemstream SHARED ${SOURCES})
 
-target_include_directories(pmemstream PRIVATE . include)
-target_include_directories(pmemstream PRIVATE ${LIBPMEM2_INCLUDE_DIRS})
+target_include_directories(pmemstream PRIVATE
+	.
+	include)
 
 target_link_libraries(pmemstream PRIVATE
-	-Wl,--version-script=${PMEMSTREAM_ROOT_DIR}/src/libpmemstream.map)
-
-target_link_libraries(pmemstream PRIVATE ${LIBPMEM2_LIBRARIES})
+	-Wl,--version-script=${PMEMSTREAM_ROOT_DIR}/src/libpmemstream.map
+	${LIBPMEM2_LIBRARIES})
 
 set_target_properties(pmemstream PROPERTIES
 	SOVERSION 1
-	PUBLIC_HEADER "include/libpmemstream.h")
+	PUBLIC_HEADER "src/include/libpmemstream.h")
 
 target_compile_definitions(pmemstream PRIVATE SRCVERSION="${SRCVERSION}")
 

--- a/src/libpmemstream.c
+++ b/src/libpmemstream.c
@@ -304,7 +304,7 @@ region_compare(const void *lhs, const void *rhs)
 static void
 pmemstream_init_txs(struct pmemstream *stream)
 {
-	for (int i = 0; i < PMEMSTREAM_NLANES; ++i) {
+	for (size_t i = 0; i < PMEMSTREAM_NLANES; ++i) {
 		struct pmemstream_tx *tx = &stream->txs[i];
 		tx->lane = &stream->data->lanes[i];
 		tx->lane_id = i;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2019-2021, Intel Corporation
+
+#
+# tests/CMakeLists.txt - prepares all tests; it specifies which tests are enabled based on options
+#	and available programs. Build tests with 'make tests' command, execute them using 'ctest'.
+#
+include(cmake/functions.cmake)
+
+# ----------------------------------------------------------------- #
+## Setup
+# ----------------------------------------------------------------- #
+add_custom_target(tests)
+
+# XXX: valgrind required only for tests? or in top-level CMake?
+# # Find valgrind
+# if(PKG_CONFIG_FOUND)
+# 	pkg_check_modules(VALGRIND QUIET valgrind)
+# else()
+# 	find_package(VALGRIND QUIET)
+# endif()
+
+if(NOT VALGRIND_FOUND AND TESTS_USE_VALGRIND)
+	message(FATAL_ERROR "Valgrind not found, but flag TESTS_USE_VALGRIND was set.")
+elseif(NOT VALGRIND_FOUND)
+	message(WARNING "Valgrind not found. Valgrind tests will not be performed.")
+elseif(VALGRIND_FOUND)
+	message(STATUS "Found Valgrind in '${VALGRIND_LIBRARY_DIRS}' (version: ${VALGRIND_VERSION})")
+endif()
+
+# find_pmemcheck()
+find_libunwind()
+# find_pmreorder()
+# find_pmempool()
+# find_gdb()
+
+# Add checks when DEVELOPER_MODE is ON
+add_cppstyle(tests ${TESTS_ROOT_DIR}/*.[chp])
+add_check_whitespace(tests ${TESTS_ROOT_DIR}/*.*
+		${CMAKE_CURRENT_SOURCE_DIR}/*/*.*)
+
+add_library(test_backtrace STATIC common/test_backtrace.c)
+if(LIBUNWIND_FOUND)
+	target_compile_definitions(test_backtrace PUBLIC USE_LIBUNWIND=1)
+endif()
+
+# XXX: add libpmemset dependency and fix 'check_is_pmem.cpp'
+#		or use libpmem library? (fix findLIBPMEM2)
+# add_executable(check_is_pmem common/check_is_pmem.cpp)
+# target_link_libraries(check_is_pmem ${LIBPMEM_LIBRARIES})
+
+if(COVERAGE AND TESTS_USE_VALGRIND)
+	message(STATUS "This is the Coverage build, skipping Valgrind tests")
+endif()
+
+# ----------------------------------------------------------------- #
+## Common tests
+# ----------------------------------------------------------------- #
+build_test(stream_from_map api_c/stream_from_map.c)
+add_test_generic(NAME stream_from_map TRACERS none)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,11 @@ include(cmake/functions.cmake)
 # ----------------------------------------------------------------- #
 add_custom_target(tests)
 
+set(CXX_STANDARD 17 CACHE STRING "C++ language standard")
+
+set(CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_STANDARD ${CXX_STANDARD})
+
 # XXX: valgrind required only for tests? or in top-level CMake?
 # # Find valgrind
 # if(PKG_CONFIG_FOUND)

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,31 @@
+# Content
+
+This directory contains tests for pmemstream and their helpers.
+Directories contains:
+
+- **api_c** - unit tests for C API,
+- **cmake** - cmake and ctest helpers, including suppressions' files and CMake executions scripts,
+- **common** - shared functions and libraries for all tests.
+
+# Tests execution
+
+Before executing tests it's required to build pmemstream's sources and tests.
+See [INSTALLING.md](../INSTALLING.md) for details. There are CMake's options related
+to tests - see all options in top-level CMakeLists.txt with prefix `TESTS_`.
+One of them - `TESTS_USE_FORCED_PMEM=ON` speeds up tests execution on emulated pmem.
+It's useful for long (e.g. concurrent) tests.
+
+To run all tests execute:
+
+```sh
+make test
+```
+
+or, if you want to see an output/logs of failed tests, run:
+
+```sh
+ctest --output-on-failure
+```
+
+There are other parameters to use in `ctest` command. To see the full list read
+[ctest(1) manpage](https://cmake.org/cmake/help/latest/manual/ctest.1.html).

--- a/tests/api_c/stream_from_map.c
+++ b/tests/api_c/stream_from_map.c
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2021, Intel Corporation */
+
+#include "unittest.h"
+
+/**
+ * stream_from_map - unit test for pmemstream_from_map
+ */
+
+void test_stream_from_map(char *path, size_t file_size, size_t blk_size)
+{
+	struct pmem2_map *map = map_open(path, file_size);
+	UT_ASSERTne(map, NULL);
+	
+	struct pmemstream *s = NULL;
+	pmemstream_from_map(&s, blk_size, map);
+	UT_ASSERTne(s, NULL);
+	
+	pmemstream_delete(&s);
+	pmem2_map_delete(&map);
+}
+
+int main(int argc, char *argv[])
+{
+	if (argc < 2) {
+		UT_FATAL("usage: %s file-name", argv[0]);
+	}
+
+	START();
+	char *path = argv[1];
+
+	test_stream_from_map(path, 4096*1024, 4096);
+	test_stream_from_map(path, 10240, 64);
+
+	return 0;
+}

--- a/tests/cmake/exec_functions.cmake
+++ b/tests/cmake/exec_functions.cmake
@@ -1,0 +1,352 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2018-2021, Intel Corporation
+
+#
+# exec_functions.cmake - helper variables and functions for
+#	execution's cmake scripts, used in tests' workflows.
+#
+
+# Sets testing path, based on TEST_DIR ('TESTS_EXECUTION_DIR' here)
+#	set in the top-level CMake.
+set(DIR ${TESTS_EXECUTION_DIR}/${TEST_NAME})
+
+set(SUPPRESSIONS_DIR ${TESTS_ROOT_DIR}/cmake/suppressions)
+
+# ----------------------------------------------------------------- #
+## Define functions to control tests' flow and prepare environment
+# ----------------------------------------------------------------- #
+
+# setup the env, by removing old binary and testfile
+function(setup)
+	execute_process(COMMAND ${CMAKE_COMMAND} -E remove_directory ${DIR})
+	execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory ${DIR})
+	execute_process(COMMAND ${CMAKE_COMMAND} -E remove_directory ${BIN_DIR})
+	execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory ${BIN_DIR})
+endfunction()
+
+function(print_logs)
+	message(STATUS "Test ${TEST_NAME}:")
+	if(EXISTS ${BIN_DIR}/${TEST_NAME}.out)
+		file(READ ${BIN_DIR}/${TEST_NAME}.out OUT)
+		message(STATUS "Stdout:\n${OUT}")
+	endif()
+	if(EXISTS ${BIN_DIR}/${TEST_NAME}.err)
+		file(READ ${BIN_DIR}/${TEST_NAME}.err ERR)
+		message(STATUS "Stderr:\n${ERR}")
+	endif()
+	if(EXISTS ${BIN_DIR}/${TEST_NAME}.pmreorder)
+	   file(READ ${BIN_DIR}/${TEST_NAME}.pmreorder PMEMREORDER)
+	   message(STATUS "Pmreorder:\n${PMEMREORDER}")
+	endif()
+endfunction()
+
+# Performs cleanup and log matching.
+function(finish)
+	print_logs()
+
+	execute_process(COMMAND ${CMAKE_COMMAND} -E remove_directory ${DIR})
+endfunction()
+
+# Verifies ${log_file} matches ${match_file} using "match".
+function(match log_file match_file)
+	execute_process(COMMAND
+			${PERL_EXECUTABLE} ${MATCH_SCRIPT} -o ${log_file} ${match_file}
+			RESULT_VARIABLE MATCH_ERROR)
+
+	if(MATCH_ERROR)
+		message(FATAL_ERROR "Log does not match: ${MATCH_ERROR}")
+	endif()
+endfunction()
+
+# Verifies file exists
+function(check_file_exists file)
+	if(NOT EXISTS ${file})
+		message(FATAL_ERROR "${file} doesn't exist")
+	endif()
+endfunction()
+
+# Verifies file doesn't exist
+function(check_file_doesnt_exist file)
+	if(EXISTS ${file})
+		message(FATAL_ERROR "${file} exists")
+	endif()
+endfunction()
+
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=810295
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=780173
+# https://bugs.kde.org/show_bug.cgi?id=303877
+#
+# valgrind issues an unsuppressable warning when exceeding
+# the brk segment, causing matching failures. We can safely
+# ignore it because malloc() will fallback to mmap() anyway.
+#
+# list of ignored warnings should match the list provided by PMDK:
+# https://github.com/pmem/pmdk/blob/master/src/test/unittest/unittest.sh
+function(valgrind_ignore_warnings valgrind_log)
+	execute_process(COMMAND bash "-c" "cat ${valgrind_log} | grep -v \
+	-e \"WARNING: Serious error when reading debug info\" \
+	-e \"When reading debug info from \" \
+	-e \"Ignoring non-Dwarf2/3/4 block in .debug_info\" \
+	-e \"Last block truncated in .debug_info; ignoring\" \
+	-e \"parse_CU_Header: is neither DWARF2 nor DWARF3 nor DWARF4\" \
+	-e \"brk segment overflow\" \
+	-e \"see section Limitations in user manual\" \
+	-e \"Warning: set address range perms: large range\"\
+	-e \"further instances of this message will not be shown\"\
+	>  ${valgrind_log}.tmp
+mv ${valgrind_log}.tmp ${valgrind_log}")
+endfunction()
+
+# XXX: refactor this long function
+#		perhaps it'd be enough to move GDB checks and setup into sep. function
+function(execute_common expect_success output_file name)
+	if(TESTS_USE_FORCED_PMEM)
+		set(ENV{PMEM_IS_PMEM_FORCE} 1)
+	endif()
+
+	if(${TRACER} STREQUAL pmemcheck)
+		if(TESTS_USE_FORCED_PMEM)
+			# pmemcheck runs really slow with pmem, disable it
+			set(ENV{PMEM_IS_PMEM_FORCE} 0)
+		endif()
+		set(TRACE valgrind --error-exitcode=99 --tool=pmemcheck)
+	elseif(${TRACER} STREQUAL memcheck)
+		set(TRACE valgrind --error-exitcode=99 --tool=memcheck --leak-check=full --max-threads=3000
+		   --suppressions=${SUPPRESSIONS_DIR}/ld.supp --suppressions=${SUPPRESSIONS_DIR}/memcheck-stdcpp.supp --suppressions=${SUPPRESSIONS_DIR}/memcheck-libunwind.supp
+		   --suppressions=${SUPPRESSIONS_DIR}/memcheck-ndctl.supp)
+	elseif(${TRACER} STREQUAL helgrind)
+		set(TRACE valgrind --error-exitcode=99 --tool=helgrind --max-threads=3000)
+	elseif(${TRACER} STREQUAL drd)
+		set(TRACE valgrind --error-exitcode=99 --tool=drd --max-threads=3000 --suppressions=${SUPPRESSIONS_DIR}/drd.supp)
+	elseif(${TRACER} STREQUAL gdb)
+		set(TRACE gdb --batch --command=${GDB_BATCH_FILE} --args)
+	elseif(${TRACER} MATCHES "none.*")
+		# nothing
+	else()
+		message(FATAL_ERROR "Unknown tracer '${TRACER}'")
+	endif()
+
+	if (NOT $ENV{CGDB})
+		if (NOT WIN32)
+			set(TRACE timeout -s SIGALRM -k 200s 180s ${TRACE})
+		endif()
+	endif()
+
+	string(REPLACE ";" " " TRACE_STR "${TRACE}")
+	message(STATUS "Executing: ${TRACE_STR} ${name} ${ARGN}")
+
+	set(cmd ${TRACE} ${name} ${ARGN})
+
+	if(DEFINED ENV{CGDB} AND DEFINED ENV{GDBSERVER})
+        message(FATAL_ERROR "CGDB and GDBSERVER shouldn't be used at the same time."
+                "You should choose one way of debugging and probably refill your coffee.")
+    endif()
+
+    if(DEFINED ENV{CGDB})
+		find_program(KONSOLE NAMES konsole)
+		find_program(GNOME_TERMINAL NAMES gnome-terminal)
+		find_program(CGDB NAMES cgdb)
+
+		if (NOT KONSOLE AND NOT GNOME_TERMINAL)
+			message(FATAL_ERROR "konsole or gnome-terminal not found.")
+		elseif (NOT CGDB)
+			message(FATAL_ERROR "cdgb not found.")
+		elseif(NOT (${TRACER} STREQUAL none))
+			message(FATAL_ERROR "Cannot use cgdb with ${TRACER}")
+		else()
+			if (KONSOLE)
+				set(cmd konsole -e cgdb --args ${cmd})
+			elseif(GNOME_TERMINAL)
+				set(cmd gnome-terminal --tab --active --wait -- cgdb --args ${cmd})
+			endif()
+		endif()
+	endif()
+
+	if(DEFINED ENV{GDBSERVER})
+        find_program(GDBSERVER NAMES gdbserver)
+        set(GDBSERVER_SETTINGS $ENV{GDBSERVER})
+        if (NOT GDBSERVER)
+            message(FATAL_ERROR "gdbserver not found.")
+        endif()
+        if(NOT (${TRACER} STREQUAL none))
+            message(FATAL_ERROR "Cannot use gdbserver with ${TRACER}")
+        endif()
+        set(cmd ${GDBSERVER} ${GDBSERVER_SETTINGS} ${cmd})
+    endif()
+
+	if(${output_file} STREQUAL none)
+		execute_process(COMMAND ${cmd}
+			OUTPUT_QUIET
+			RESULT_VARIABLE res)
+	else()
+		execute_process(COMMAND ${cmd}
+			RESULT_VARIABLE res
+			OUTPUT_FILE ${BIN_DIR}/${TEST_NAME}.out
+			ERROR_FILE ${BIN_DIR}/${TEST_NAME}.err)
+	endif()
+
+	print_logs()
+
+	# pmemcheck is a special snowflake and it doesn't set exit code when
+	# it detects an error, so we have to look at its output if match file
+	# was not found.
+	if(${TRACER} STREQUAL pmemcheck)
+		if(NOT EXISTS ${BIN_DIR}/${TEST_NAME}.err)
+			message(FATAL_ERROR "${TEST_NAME}.err not found.")
+		endif()
+
+		file(READ ${BIN_DIR}/${TEST_NAME}.err PMEMCHECK_ERR)
+		message(STATUS "Stderr:\n${PMEMCHECK_ERR}\nEnd of stderr")
+		if(NOT PMEMCHECK_ERR MATCHES "ERROR SUMMARY: 0")
+			message(FATAL_ERROR "${TRACE} ${name} ${ARGN} failed: ${res}")
+		endif()
+	endif()
+
+	if(res AND expect_success)
+		message(FATAL_ERROR "${TRACE} ${name} ${ARGN} failed: ${res}")
+	endif()
+
+	if(NOT res AND NOT expect_success)
+		message(FATAL_ERROR "${TRACE} ${name} ${ARGN} unexpectedly succeeded: ${res}")
+	endif()
+
+	if(TESTS_USE_FORCED_PMEM)
+		unset(ENV{PMEM_IS_PMEM_FORCE})
+	endif()
+endfunction()
+
+# Checks if target (test binary) was built
+function(check_target name)
+	if(NOT EXISTS ${name})
+		message(FATAL_ERROR "Test file: \"${name}\" was not found! If test wasn't built, run make first.")
+	endif()
+endfunction()
+
+# Generic command executor which handles failures and prints command output
+# to specified file.
+function(execute_with_output out name)
+	check_target(${name})
+
+	execute_common(true ${out} ${name} ${ARGN})
+endfunction()
+
+# Generic command executor which handles failures but ignores output.
+function(execute_ignore_output name)
+	check_target(${name})
+
+	execute_common(true none ${name} ${ARGN})
+endfunction()
+
+# Executes test command ${name} and verifies its status.
+# First argument of the command is test directory name.
+# Optional function arguments are passed as consecutive arguments to
+# the command.
+function(execute name)
+	check_target(${name})
+
+	execute_common(true ${TRACER}_${TESTCASE} ${name} ${ARGN})
+endfunction()
+
+# Executes command ${name} and creates a storelog.
+# First argument is pool file.
+# Second argument is test executable.
+# Optional function arguments are passed as consecutive arguments to
+# the command.
+function(pmreorder_create_store_log pool name)
+	check_target(${name})
+
+	if(NOT (${TRACER} STREQUAL none))
+		message(FATAL_ERROR "Pmreorder test must be run without any tracer.")
+	endif()
+
+	configure_file(${pool} ${pool}.copy COPYONLY)
+
+	set(ENV{PMREORDER_EMIT_LOG} 1)
+
+	if(DEFINED ENV{PMREORDER_STACKTRACE_DEPTH})
+		set(PMREORDER_STACKTRACE_DEPTH $ENV{PMREORDER_STACKTRACE_DEPTH})
+		set(PMREORDER_STACKTRACE "yes")
+	else()
+		set(PMREORDER_STACKTRACE_DEPTH 1)
+		set(PMREORDER_STACKTRACE "no")
+	endif()
+
+	set(cmd valgrind --tool=pmemcheck -q
+		--log-stores=yes
+		--print-summary=no
+		--log-file=${BIN_DIR}/${TEST_NAME}.storelog
+		--log-stores-stacktraces=${PMREORDER_STACKTRACE}
+		--log-stores-stacktraces-depth=${PMREORDER_STACKTRACE_DEPTH}
+		--expect-fence-after-clflush=yes
+		${name} ${ARGN})
+
+	execute_common(true ${TRACER}_${TESTCASE} ${cmd})
+
+	file(READ ${BIN_DIR}/${TEST_NAME}.storelog STORELOG)
+	string(REPLACE "operator|=" "operator_OR" FIXED_STORELOG "${STORELOG}")
+	file(WRITE ${BIN_DIR}/${TEST_NAME}.storelog "${FIXED_STORELOG}")
+
+	unset(ENV{PMREORDER_EMIT_LOG})
+
+	file(REMOVE ${pool})
+	configure_file(${pool}.copy ${pool} COPYONLY)
+endfunction()
+
+# Executes pmreorder.
+# First argument is expected result.
+# Second argument is engine type.
+# Third argument is path to configure file.
+# Fourth argument is path to the checker program.
+# Optional function arguments are passed as consecutive arguments to
+# the command.
+function(pmreorder_execute expect_success engine conf_file name)
+	check_target(${name})
+
+	if(NOT (${TRACER} STREQUAL none))
+		message(FATAL_ERROR "Pmreorder test must be run without any tracer.")
+	endif()
+
+	set(ENV{PMEMOBJ_CONF} "copy_on_write.at_open=1")
+
+	string(REPLACE "\"" "\\\"" ESCAPED_ARGN "${ARGN}")
+
+	set(cmd pmreorder -l ${BIN_DIR}/${TEST_NAME}.storelog
+					-o ${BIN_DIR}/${TEST_NAME}.pmreorder
+					-r ${engine}
+					-p "${name} ${ESCAPED_ARGN}"
+					-x ${conf_file})
+
+	execute_common(${expect_success} ${TRACER}_${TESTCASE} ${cmd})
+
+	unset(ENV{PMEMOBJ_CONF})
+endfunction()
+
+# Executes test command ${name} under GDB.
+# First argument of the command is a gdb batch file.
+# Second argument of the command is the test command.
+# Optional function arguments are passed as consecutive arguments to
+# the command.
+function(crash_with_gdb gdb_batch_file name)
+	check_target(${name})
+
+	set(PREV_TRACER ${TRACER})
+	set(TRACER gdb)
+	set(GDB_BATCH_FILE ${gdb_batch_file})
+
+	execute_common(true ${TRACER}_${TESTCASE} ${name} ${ARGN})
+
+	set(TRACER ${PREV_TRACER})
+endfunction()
+
+# Checks whether specified filename is located on persistent memory and emits
+# FATAL_ERROR in case it's not.
+function(check_is_pmem filename)
+	execute_process(COMMAND ${BIN_DIR}/../check_is_pmem ${filename} RESULT_VARIABLE is_pmem)
+
+	if (${is_pmem} EQUAL 2)
+		message(FATAL_ERROR "check_is_pmem failed.")
+	elseif ((${is_pmem} EQUAL 1) AND (NOT TESTS_USE_FORCED_PMEM))
+		# Return value 1 means that path points to non-pmem
+		message(FATAL_ERROR "${TEST_NAME} can only be run on PMEM.")
+	endif()
+endfunction()

--- a/tests/cmake/functions.cmake
+++ b/tests/cmake/functions.cmake
@@ -1,0 +1,313 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2018-2021, Intel Corporation
+
+#
+# functions.cmake - helper variables and functions for tests/CMakeLists.txt:
+#	- finding packages,
+#	- building and adding test cases.
+#
+
+set(TESTS_ROOT_DIR ${PMEMSTREAM_ROOT_DIR}/tests)
+
+set(GLOBAL_TEST_ARGS
+	-DPERL_EXECUTABLE=${PERL_EXECUTABLE}
+	-DMATCH_SCRIPT=${PROJECT_SOURCE_DIR}/tests/cmake/match
+	-DTESTS_USE_FORCED_PMEM=${TESTS_USE_FORCED_PMEM}
+	-DTESTS_ROOT_DIR=${TESTS_ROOT_DIR}
+	-DTESTS_EXECUTION_DIR=${TEST_DIR})
+
+if(TRACE_TESTS)
+	set(GLOBAL_TEST_ARGS ${GLOBAL_TEST_ARGS} --trace-expand)
+endif()
+
+# List of supported Valgrind tracers
+set(vg_tracers memcheck helgrind drd pmemcheck)
+
+# Set dir where PMDK tools' binaries are held
+set(PMDK_BIN_PREFIX ${LIBPMEM2_PREFIX}/bin)
+
+# ----------------------------------------------------------------- #
+## Include and link required dirs/libs for tests
+# ----------------------------------------------------------------- #
+
+# XXX: add for libpmemset/libpmem ?
+set(INCLUDE_DIRS common/ ../src ../src/include)
+#set(LIBS_DIRS ${})
+
+include_directories(${INCLUDE_DIRS})
+link_directories(${LIBS_DIRS})
+
+# ----------------------------------------------------------------- #
+## Functions to find packages in the system
+# ----------------------------------------------------------------- #
+function(find_gdb)
+	find_program(GDB gdb)
+	if(GDB)
+		set(ENV{PATH} ${PMDK_BIN_PREFIX}:$ENV{PATH})
+		message(STATUS "Found gdb: ${GDB}")
+	else()
+		message(WARNING "gdb not found, some tests will be skipped.")
+	endif()
+endfunction()
+
+function(find_pmemcheck)
+	if(WIN32)
+		return()
+	endif()
+
+	if(NOT VALGRIND_FOUND)
+		return()
+	endif()
+
+	set(ENV{PATH} ${VALGRIND_PREFIX}/bin:$ENV{PATH})
+	execute_process(COMMAND valgrind --tool=pmemcheck --help
+			RESULT_VARIABLE VALGRIND_PMEMCHECK_RET
+			OUTPUT_QUIET
+			ERROR_QUIET)
+	if(VALGRIND_PMEMCHECK_RET)
+		set(VALGRIND_PMEMCHECK_FOUND 0 CACHE INTERNAL "")
+	else()
+		set(VALGRIND_PMEMCHECK_FOUND 1 CACHE INTERNAL "")
+	endif()
+
+	if(VALGRIND_PMEMCHECK_FOUND)
+		execute_process(COMMAND valgrind --tool=pmemcheck true
+				ERROR_VARIABLE PMEMCHECK_OUT
+				OUTPUT_QUIET)
+
+		string(REGEX MATCH ".*pmemcheck-([0-9.]+),.*" PMEMCHECK_OUT "${PMEMCHECK_OUT}")
+		set(PMEMCHECK_VERSION ${CMAKE_MATCH_1} CACHE INTERNAL "")
+		message(STATUS "Valgrind pmemcheck found, version: ${PMEMCHECK_VERSION}")
+	else()
+		message(WARNING "Valgrind pmemcheck not found. Pmemcheck tests will not be performed.")
+	endif()
+endfunction()
+
+function(find_libunwind)
+	if(PKG_CONFIG_FOUND)
+		pkg_check_modules(LIBUNWIND QUIET libunwind)
+	else()
+		find_package(LIBUNWIND QUIET)
+	endif()
+
+	if(NOT LIBUNWIND_FOUND)
+		message(WARNING "libunwind not found. Stack traces from tests will not be reliable")
+	else()
+		message(STATUS "Found libunwind, version ${LIBUNWIND_VERSION}")
+	endif()
+endfunction()
+
+function(find_pmreorder)
+	if(NOT VALGRIND_FOUND OR NOT VALGRIND_PMEMCHECK_FOUND)
+		message(WARNING "Pmreorder will not be used. Valgrind with pmemcheck must be installed")
+		return()
+	endif()
+
+	if((NOT(PMEMCHECK_VERSION VERSION_LESS 1.0)) AND PMEMCHECK_VERSION VERSION_LESS 2.0)
+		find_program(PMREORDER names pmreorder HINTS ${PMDK_BIN_PREFIX})
+
+		if(PMREORDER)
+			get_program_version_major_minor(${PMREORDER} PMREORDER_VERSION)
+			message(STATUS "Found pmreorder: ${PMREORDER}, in version: ${PMREORDER_VERSION}")
+
+			set(ENV{PATH} ${PMDK_BIN_PREFIX}:$ENV{PATH})
+			set(PMREORDER_SUPPORTED true CACHE INTERNAL "pmreorder support")
+		else()
+			message(WARNING "Pmreorder not found - pmreorder tests will not be performed.")
+		endif()
+	else()
+		message(WARNING "Pmemcheck must be installed in version 1.X for pmreorder to work - pmreorder tests will not be performed.")
+	endif()
+endfunction()
+
+function(find_pmempool)
+	find_program(PMEMPOOL names pmempool HINTS ${PMDK_BIN_PREFIX})
+	if(PMEMPOOL)
+		set(ENV{PATH} ${PMDK_BIN_PREFIX}:$ENV{PATH})
+		message(STATUS "Found pmempool: ${PMEMPOOL}")
+	else()
+		message(FATAL_ERROR "Pmempool not found.")
+	endif()
+endfunction()
+
+# ----------------------------------------------------------------- #
+## Functions for building and adding new testcases
+# ----------------------------------------------------------------- #
+
+# Function to build test with custom build options (e.g. passing defines),
+# link it with custom library/-ies and compile options. It calls build_test function.
+# Usage: build_test_ext(NAME .. SRC_FILES .. .. LIBS .. .. BUILD_OPTIONS .. .. OPTS .. ..)
+function(build_test_ext)
+	set(oneValueArgs NAME)
+	set(multiValueArgs SRC_FILES LIBS BUILD_OPTIONS OPTS)
+	cmake_parse_arguments(TEST "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+	set(LIBS_TO_LINK "")
+
+	if(${TEST_NAME} MATCHES "posix$" AND WIN32)
+		return()
+	endif()
+
+	foreach(lib ${TEST_LIBS})
+		if("${lib}" STREQUAL "libpmemobj_cpp")
+			if("${LIBPMEMOBJ++_LIBRARIES}" STREQUAL "")
+				return()
+			else()
+				list(APPEND LIBS_TO_LINK ${LIBPMEMOBJ++_LIBRARIES})
+			endif()
+		elseif("${lib}" STREQUAL "dl_libs")
+			list(APPEND LIBS_TO_LINK ${CMAKE_DL_LIBS})
+		endif()
+	endforeach()
+
+	build_test(${TEST_NAME} ${TEST_SRC_FILES})
+	target_link_libraries(${TEST_NAME} ${LIBS_TO_LINK})
+	target_compile_definitions(${TEST_NAME} PRIVATE ${TEST_BUILD_OPTIONS})
+	target_compile_options(${TEST_NAME} PRIVATE ${TEST_OPTS})
+endfunction()
+
+# Prepares test executable with given {name} and extra arguments equal to source files({ARGN}).
+function(build_test name)
+	if(${name} MATCHES "posix$" AND WIN32)
+		return()
+	endif()
+
+	set(srcs ${ARGN})
+	prepend(srcs ${TESTS_ROOT_DIR} ${srcs})
+
+	add_executable(${name} ${srcs})
+	target_link_libraries(${name} ${CMAKE_THREAD_LIBS_INIT} ${LIBPMEM2_LIBRARIES} pmemstream test_backtrace)
+	if(LIBUNWIND_FOUND)
+		target_link_libraries(${name} ${LIBUNWIND_LIBRARIES} ${CMAKE_DL_LIBS})
+	endif()
+	if(WIN32)
+		target_link_libraries(${name} dbghelp)
+	endif()
+
+	# build it, when building 'tests'
+	add_dependencies(tests ${name})
+endfunction()
+
+# Configures ctest's testcase with the name: ${test_name}_${testcase}_${tracer}.
+# It passes CMake params, including GLOBAL_TEST_ARGS and test specific args, like
+# cmake_script (to run the test), test_name, test case number, tracer, and dirs.  
+# XXX: SRC_DIR is wrong, because we add tests with srcs like "api_c/testname.c"
+#	   and we get actually parent dir (e.g. "../tests" instead of "../tests/api_c").
+#	   We could solve this with per-dir CMake files (i.a. add CMake in api_c dir)
+function(add_testcase test_name tracer testcase cmake_script)
+	add_test(NAME ${test_name}_${testcase}_${tracer}
+			COMMAND ${CMAKE_COMMAND}
+			${GLOBAL_TEST_ARGS}
+			-DEXECUTABLE=$<TARGET_FILE:${test_name}>
+			-DTEST_NAME=${test_name}_${testcase}_${tracer}
+			-DTESTCASE=${testcase}
+			-DTRACER=${tracer}
+			-DSRC_DIR=${CMAKE_CURRENT_SOURCE_DIR}
+			-DBIN_DIR=${CMAKE_CURRENT_BINARY_DIR}/${test_name}_${testcase}_${tracer}
+			${ARGN}
+			-P ${cmake_script})
+
+	set_tests_properties(${test_name}_${testcase}_${tracer} PROPERTIES
+			ENVIRONMENT "LC_ALL=C;PATH=$ENV{PATH};"
+			FAIL_REGULAR_EXPRESSION Sanitizer)
+
+	# XXX: if we use FATAL_ERROR in test.cmake - pmemcheck passes anyway
+	# workaround: look for "CMake Error" in output and fail if found
+	if (${tracer} STREQUAL pmemcheck)
+		set_tests_properties(${test_name}_${testcase}_${tracer} PROPERTIES
+				FAIL_REGULAR_EXPRESSION "CMake Error")
+	endif()
+
+	if (${tracer} STREQUAL pmemcheck)
+		set_tests_properties(${test_name}_${testcase}_${tracer} PROPERTIES
+				COST 100)
+	elseif(${tracer} IN_LIST vg_tracers)
+		set_tests_properties(${test_name}_${testcase}_${tracer} PROPERTIES
+				COST 50)
+	else()
+		set_tests_properties(${test_name}_${testcase}_${tracer} PROPERTIES
+				COST 10)
+	endif()
+endfunction()
+
+# Skipped test cases execute nothing and contain skip message in the name. 
+function(skip_test name message)
+	add_test(NAME ${name}_${message}
+		COMMAND ${CMAKE_COMMAND} -P ${TESTS_ROOT_DIR}/true.cmake)
+
+	set_tests_properties(${name}_${message} PROPERTIES COST 0)
+endfunction()
+
+# Adds testcase if all checks passes, e.g., tracer is found, executable (target) is built, etc.
+#	It skips otherwise and prints message if needed.
+function(add_test_common test_name tracer testcase cmake_script)
+	if(${tracer} STREQUAL "")
+	    set(tracer none)
+	endif()
+
+	if(${tracer} IN_LIST vg_tracers)
+		if(TESTS_USE_VALGRIND)
+			# pmemcheck is not necessarily required (because it's not always delivered with Valgrind)
+			if(${tracer} STREQUAL "pmemcheck" AND (NOT VALGRIND_PMEMCHECK_FOUND))
+				skip_test(${name}_${testcase}_${tracer} "SKIPPED_BECAUSE_OF_MISSING_PMEMCHECK")
+				return()
+			# Valgrind on the other hand is required, because we enabled Valgrind tests
+			elseif(NOT VALGRIND_FOUND)
+				message(FATAL_ERROR "Valgrind not found, but tests are enabled. To disable them set CMake option TESTS_USE_VALGRIND=OFF.")
+			endif()
+		else()
+			# TESTS_USE_VALGRIND=OFF so just don't run Valgrind tests
+			return()
+		endif()
+
+		if(USE_ASAN OR USE_UBSAN)
+			skip_test(${name}_${testcase}_${tracer} "SKIPPED_BECAUSE_SANITIZER_USED")
+			return()
+		endif()
+
+		# skip all valgrind tests on Windows
+		if (WIN32)
+			return()
+		endif()
+
+		# skip valgrind tests when measuring code coverage
+		if (COVERAGE)
+			return()
+		endif()
+	endif()
+
+	# check if test was built
+	if (NOT TARGET ${test_name})
+		message(WARNING "${test_name} not built. Skipping.")
+		return()
+	endif()
+
+	add_testcase(${test_name} ${tracer} ${testcase} ${cmake_script} ${ARGN})
+endfunction()
+
+# Adds testcase with optional SCRIPT and CASE parameters.
+#	If not set, use default test script and set TEST_CASE to 0.
+function(add_test_generic)
+	set(oneValueArgs NAME CASE SCRIPT)
+	set(multiValueArgs TRACERS)
+	cmake_parse_arguments(TEST "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+	if("${TEST_SCRIPT}" STREQUAL "")
+		if("${TEST_CASE}" STREQUAL "")
+			set(TEST_CASE "0")
+			set(cmake_script ${TESTS_ROOT_DIR}/cmake/run_default.cmake)
+		else()
+			# XXX: perhaps we'll have to fix this when we establish hierarchy, e.g.
+			#	add sep. functions like this, to setup proper TEST_SCRIPT for a grup of tests?
+			set(cmake_script ${SRC_DIR}/${TEST_NAME}_${TEST_CASE}.cmake)
+		endif()
+	else()
+		if("${TEST_CASE}" STREQUAL "")
+			set(TEST_CASE "0")
+		endif()
+		set(cmake_script ${TESTS_ROOT_DIR}/${TEST_SCRIPT})
+	endif()
+
+	foreach(tracer ${TEST_TRACERS})
+		add_test_common(${TEST_NAME} ${tracer} ${TEST_CASE} ${cmake_script})
+	endforeach()
+endfunction()

--- a/tests/cmake/match
+++ b/tests/cmake/match
@@ -1,0 +1,300 @@
+#!/usr/bin/env perl
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2014-2021, Intel Corporation
+#
+
+#
+# match -- compare an output file with expected results
+#
+# usage: match [-adoqv] [match-file]...
+#
+# this script compares the output from a test run, stored in a file, with
+# the expected output.  comparison is done line-by-line until either all
+# lines compare correctly (exit code 0) or a miscompare is found (exit
+# code nonzero).
+#
+# expected output is stored in a ".match" file, which contains a copy of
+# the expected output with embedded tokens for things that should not be
+# exact matches.  the supported tokens are:
+#
+#	$(N)	an integer (i.e. one or more decimal digits)
+#	$(NC)	one or more decimal digits with comma separators
+#	$(FP)	a floating point number
+#	$(S)	ascii string
+#	$(X)	hex number
+#	$(XX)	hex number prefixed with 0x
+#	$(W)	whitespace
+#	$(nW)	non-whitespace
+#	$(*)	any string
+#	$(DD)	output of a "dd" run
+#	$(OPT)	line is optional (may be missing, matched if found)
+#	$(OPX)	ends a contiguous list of $(OPT)...$(OPX) lines, at least
+#		one of which must match
+#	${string1|string2} string1 OR string2
+#
+# Additionally, if any "X.ignore" file exists, strings or phrases found per
+# line in the file will be ignored if found as a substring in the
+# corresponding output file (making it easy to skip entire output lines).
+#
+# arguments are:
+#
+#	-a	find all files of the form "X.match" in the current
+#		directory and match them again the corresponding file "X".
+#
+#	-o	custom output filename - only one match file can be given
+#
+#	-d	debug -- show lots of debug output
+#
+#	-q	don't print log files on mismatch
+#
+#	-v	verbose -- show every line as it is being matched
+#
+
+use strict;
+use Getopt::Std;
+use Encode;
+use v5.16;
+
+select STDERR;
+binmode(STDOUT, ":utf8");
+binmode(STDERR, ":utf8");
+
+my $Me = $0;
+$Me =~ s,.*/,,;
+
+our ($opt_a, $opt_d, $opt_q, $opt_v, $opt_o);
+
+$SIG{HUP} = $SIG{INT} = $SIG{TERM} = $SIG{__DIE__} = sub {
+	die @_ if $^S;
+	my $errstr = shift;
+	die "FAIL: $Me: $errstr";
+};
+
+sub usage {
+	my $msg = shift;
+
+	warn "$Me: $msg\n" if $msg;
+	warn "Usage: $Me [-adqv] [match-file]...\n";
+	warn "   or: $Me [-dqv] -o output-file match-file...\n";
+	exit 1;
+}
+
+getopts('adoqv') or usage;
+
+my %match2file;
+
+if ($opt_a) {
+	usage("-a and filename arguments are mutually exclusive")
+		if $#ARGV != -1;
+	opendir(DIR, '.') or die "opendir: .: $!\n";
+	my @matchfiles = grep { /(.*)\.match$/ && -f $1 } readdir(DIR);
+	closedir(DIR);
+	die "no files found to process\n" unless @matchfiles;
+	foreach my $mfile (@matchfiles)  {
+		die "$mfile: $!\n" unless open(F, $mfile);
+		close(F);
+		my $ofile = $mfile;
+		$ofile =~ s/\.match$//;
+		die "$mfile found but cannot open $ofile: $!\n"
+			unless open(F, $ofile);
+		close(F);
+		$match2file{$mfile} = $ofile;
+	}
+} elsif ($opt_o) {
+	usage("-o argument requires two paths") if $#ARGV != 1;
+
+	$match2file{$ARGV[1]} = $ARGV[0];
+} else {
+	usage("no match-file arguments found") if $#ARGV == -1;
+
+	# to improve the failure case, check all filename args exist and
+	# are provided in pairs now, before going through and processing them
+	foreach my $mfile (@ARGV) {
+		my $ofile = $mfile;
+		usage("$mfile: not a .match file") unless
+			$ofile =~ s/\.match$//;
+		usage("$mfile: $!") unless open(F, $mfile);
+		close(F);
+		usage("$ofile: $!") unless open(F, $ofile);
+		close(F);
+		$match2file{$mfile} = $ofile;
+	}
+}
+
+my $mfile;
+my $ofile;
+my $ifile;
+print "Files to be processed:\n" if $opt_v;
+foreach $mfile (sort keys %match2file) {
+	$ofile = $match2file{$mfile};
+	$ifile = $ofile . ".ignore";
+	$ifile = undef unless (-f $ifile);
+	if ($opt_v) {
+		print "        match-file \"$mfile\" output-file \"$ofile\"";
+		if ($ifile) {
+			print " ignore-file $ifile\n";
+		} else {
+			print "\n";
+		}
+	}
+	match($mfile, $ofile, $ifile);
+}
+
+exit 0;
+
+#
+# strip_it - user can optionally ignore lines from files that contain
+# any number of substrings listed in a file called "X.ignore" where X
+# is the name of the output file.
+#
+sub strip_it {
+	my ($ifile, $file, $input) = @_;
+	# if there is no ignore file just return unaltered input
+	return $input unless $ifile;
+	my @lines_in = split /^/, $input;
+	my $output;
+	my $line_in;
+	my @i_file = split /^/, snarf($ifile);
+	my $i_line;
+	my $ignore_it = 0;
+
+	foreach $line_in (@lines_in) {
+		my @i_lines = @i_file;
+		foreach $i_line (@i_lines) {
+			chop($i_line);
+			if (index($line_in, $i_line) != -1) {
+				$ignore_it = 1;
+				if ($opt_v) {
+					print "Ignoring (from $file): $line_in";
+				}
+			}
+		}
+		if ($ignore_it == 0) {
+			$output .= $line_in;
+		}
+		$ignore_it = 0;
+	}
+	return $output;
+}
+
+#
+# match -- process a match-file, output-file pair
+#
+sub match {
+	my ($mfile, $ofile, $ifile) = @_;
+	my $pat;
+	my $output = snarf($ofile);
+	$output = strip_it($ifile, $ofile, $output);
+	my $all_lines = $output;
+	my $line_pat = 0;
+	my $line_out = 0;
+	my $opt = 0;
+	my $opx = 0;
+	my $opt_found = 0;
+	my $fstr = snarf($mfile);
+	$fstr = strip_it($ifile, $mfile, $fstr);
+	for (split /^/, $fstr) {
+		$pat = $_;
+		$line_pat++;
+		$line_out++;
+		s/([*+?|{}.\\^\$\[()])/\\$1/g;
+		s/\\\$\\\(FP\\\)/[-+]?\\d*\\.?\\d+([eE][-+]?\\d+)?/g;
+		s/\\\$\\\(N\\\)/[-+]?\\d+/g;
+		s/\\\$\\\(NC\\\)/[-+]?\\d+(,[0-9]+)*/g;
+		s/\\\$\\\(\\\*\\\)/\\p{Print}*/g;
+		s/\\\$\\\(S\\\)/\\P{IsC}+/g;
+		s/\\\$\\\(X\\\)/\\p{XPosixXDigit}+/g;
+		s/\\\$\\\(XX\\\)/0x\\p{XPosixXDigit}+/g;
+		s/\\\$\\\(W\\\)/\\p{Blank}*/g;
+		s/\\\$\\\(nW\\\)/\\p{Graph}*/g;
+		s/\\\$\\\{([^|]*)\\\|([^|]*)\\\}/($1|$2)/g;
+		s/\\\$\\\(DD\\\)/\\d+\\+\\d+ records in\n\\d+\\+\\d+ records out\n\\d+ bytes \\\(\\d+ .B\\\) copied, [.0-9e-]+[^,]*, [.0-9]+ .B.s/g;
+		if (s/\\\$\\\(OPT\\\)//) {
+			$opt = 1;
+		} elsif (s/\\\$\\\(OPX\\\)//) {
+			$opx = 1;
+		} else {
+			$opt_found = 0;
+		}
+
+		if ($opt_v) {
+			my @lines = split /\n/, $output;
+			my $line;
+			if (@lines) {
+				$line = $lines[0];
+			} else {
+				$line = "[EOF]";
+			}
+
+			printf("%s:%-3d %s%s:%-3d       %s\n", $mfile, $line_pat, $pat, $ofile, $line_out, $line);
+		}
+
+		print " => /$_/\n" if $opt_d;
+		print " [$output]\n" if $opt_d;
+		unless ($output =~ s/^$_//) {
+			if ($opt || ($opx && $opt_found)) {
+				printf("%s:%-3d      [skipping optional line]\n", $ofile, $line_out) if $opt_v;
+				$line_out--;
+				$opt = 0;
+			} else {
+				if (!$opt_v) {
+					if ($opt_q) {
+						print "[MATCHING FAILED]\n";
+					} else {
+						print "[MATCHING FAILED, COMPLETE FILE ($ofile) BELOW]\n$all_lines\n[EOF]\n";
+					}
+					$opt_v = 1;
+					match($mfile, $ofile);
+				}
+
+				die "$mfile:$line_pat did not match pattern\n";
+			}
+		} elsif ($opt) {
+			$opt_found = 1;
+		}
+		$opx = 0;
+	}
+
+	if ($output ne '') {
+		if (!$opt_v) {
+			if ($opt_q) {
+				print "[MATCHING FAILED]\n";
+			} else {
+				print "[MATCHING FAILED, COMPLETE FILE ($ofile) BELOW]\n$all_lines\n[EOF]\n";
+			}
+		}
+
+		# make it a little more print-friendly...
+		$output =~ s/\n/\\n/g;
+		die "line $line_pat: unexpected output: \"$output\"\n";
+	}
+}
+
+
+#
+# snarf -- slurp an entire file into memory
+#
+sub snarf {
+	my ($file) = @_;
+	my $fh;
+	open($fh, '<', $file) or die "$file $!\n";
+
+	local $/;
+	$_ = <$fh>;
+	close $fh;
+
+	# check known encodings or die
+	my $decoded;
+	my @encodings = ("UTF-8", "UTF-16", "UTF-16LE", "UTF-16BE");
+
+	foreach my $enc (@encodings) {
+		eval { $decoded = decode( $enc, $_, Encode::FB_CROAK ) };
+
+		if (!$@) {
+			$decoded =~ s/\R/\n/g;
+			return $decoded;
+		}
+	}
+
+	die "$Me: ERROR: Unknown file encoding";
+}

--- a/tests/cmake/pmreorder.conf
+++ b/tests/cmake/pmreorder.conf
@@ -1,0 +1,4 @@
+{
+	"no_reorder" : "NoReorderNoCheck"
+}
+

--- a/tests/cmake/run_default.cmake
+++ b/tests/cmake/run_default.cmake
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2019-2021, Intel Corporation
+
+include(${TESTS_ROOT_DIR}/cmake/exec_functions.cmake)
+
+setup()
+
+execute(${EXECUTABLE} ${DIR}/testfile)
+
+finish()

--- a/tests/cmake/suppressions/drd.supp
+++ b/tests/cmake/suppressions/drd.supp
@@ -1,0 +1,28 @@
+{
+   Conditional variable destruction false-positive
+   drd:CondErr
+   ...
+   fun:pthread_cond_destroy@*
+   ...
+}
+{
+   Pthread mutex lock false positive
+   Drd:Race
+   ...
+   fun:pthread_mutex_*lock*
+   ...
+}
+{
+   Pthread rwlock lock false positive
+   Drd:Race
+   ...
+   fun:pthread_rwlock_*lock*
+   ...
+}
+{
+   Dl lookup
+   drd:ConflictingAccess
+   fun:_dl_lookup_symbol_x
+   fun:_dl_fixup
+   fun:_dl_runtime_resolve_xsave
+}

--- a/tests/cmake/suppressions/ld.supp
+++ b/tests/cmake/suppressions/ld.supp
@@ -1,0 +1,41 @@
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   fun:index
+   fun:expand_dynamic_string_token
+   fun:_dl_map_object
+   fun:map_doit
+   fun:_dl_catch_error
+   fun:do_preload
+   fun:dl_main
+   fun:_dl_sysdep_start
+   fun:_dl_start
+   obj:/lib/x86_64-linux-gnu/ld-2.*.so
+   obj:*
+   obj:*
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   fun:index
+   fun:expand_dynamic_string_token
+   fun:_dl_map_object
+   fun:map_doit
+   fun:_dl_catch_error
+   fun:do_preload
+   fun:handle_ld_preload
+   fun:dl_main
+   fun:_dl_sysdep_start
+   fun:_dl_start
+   obj:/lib/x86_64-linux-gnu/ld-2.*.so
+   obj:*
+}
+{
+   <Leak in dlopen, pmem/issues#858>
+   Memcheck:Leak
+   ...
+   fun:_dl_init
+   fun:dl_open_worker
+   fun:_dl_catch_error
+   ...
+}

--- a/tests/cmake/suppressions/memcheck-libunwind.supp
+++ b/tests/cmake/suppressions/memcheck-libunwind.supp
@@ -1,0 +1,37 @@
+{
+   generic libunwind suppression
+   Memcheck:Param
+   msync(start)
+   ...
+   obj:*libunwind*
+   ...
+}
+{
+   generic libunwind suppression
+   Memcheck:Param
+   rt_sigprocmask(set)
+   ...
+   obj:*libunwind*
+   ...
+}
+{
+   generic libunwind suppression
+   Memcheck:Addr8
+   ...
+   obj:*libunwind*
+   ...
+}
+{
+   libunwind exception suppresion
+   Memcheck:Param
+   write(buf)
+   ...
+   obj:*libunwind*
+   ...
+}
+{
+   libunwind calls glibc's setcontext on some architectures, e.g. ppc
+   Memcheck:Addr8
+   fun:setcontext*
+   ...
+}

--- a/tests/cmake/suppressions/memcheck-ndctl.supp
+++ b/tests/cmake/suppressions/memcheck-ndctl.supp
@@ -1,0 +1,37 @@
+{
+   ndctl suppression
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:realloc
+   ...
+   fun:ndctl_pfn_get_first
+   fun:ndctl_namespace_get_pfn
+   ...
+}
+{
+   ndctl suppression
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:realloc
+   ...
+   fun:ndctl_dax_get_first
+   ...
+}
+{
+   memory leak in ndctl 63
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   ...
+   fun:ndctl_namespace_get_first_badblock
+   ...
+}
+{
+   cond jump in libkmod
+   Memcheck:Cond
+   ...
+   fun:kmod_module_new_from_lookup
+   ...
+   fun:ndctl_region_get_first
+   ...
+}

--- a/tests/cmake/suppressions/memcheck-stdcpp.supp
+++ b/tests/cmake/suppressions/memcheck-stdcpp.supp
@@ -1,0 +1,11 @@
+{
+   https://bugs.kde.org/show_bug.cgi?id=345307, https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65434, https://gcc.gnu.org/bugzilla/show_bug.cgi?id=64535
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   obj:*/libstdc++.so.*
+   fun:call_init.part.0
+   ...
+   fun:_dl_init
+   obj:*/ld-*.so
+}

--- a/tests/cmake/true.cmake
+++ b/tests/cmake/true.cmake
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2020-2021, Intel Corporation
+
+# true.cmake - cmake script which always succeeds
+
+return()

--- a/tests/common/check_is_pmem.cpp
+++ b/tests/common/check_is_pmem.cpp
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2019-2021, Intel Corporation */
+
+/*
+ * check_is_pmem.cpp -- check if path points to a directory on pmem.
+ */
+
+#include <cstdio>
+#include <iostream>
+#include <libpmem.h>
+
+/*
+ * return value is:
+ * - 0 when path points to pmem
+ * - 1 when path points to non-pmem
+ * - 2 when error occurred
+ */
+int main(int argc, char *argv[])
+{
+	if (argc != 2) {
+		std::cerr << "usage: " << argv[0] << " filepath\n";
+		return 2;
+	}
+
+	auto path = argv[1];
+
+	int is_pmem;
+	size_t size;
+	int flags = PMEM_FILE_CREATE;
+
+#ifdef _WIN32
+	void *addr = pmem_map_fileU(path, 4096, flags, 0, &size, &is_pmem);
+#else
+	void *addr = pmem_map_file(path, 4096, flags, 0, &size, &is_pmem);
+#endif
+	if (addr == nullptr) {
+		perror("pmem_map_file failed");
+		return 2;
+	}
+
+	pmem_unmap(addr, size);
+	if (remove(path) != 0) {
+		perror("remove(path) failed");
+		return 2;
+	}
+
+	if (is_pmem)
+		return 0;
+	else
+		return 1;
+}

--- a/tests/common/pthread_common.hpp
+++ b/tests/common/pthread_common.hpp
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2018-2021, Intel Corporation */
+#ifndef PMEMSTREAM_PTHREAD_COMMON_HPP
+#define PMEMSTREAM_PTHREAD_COMMON_HPP
+
+#include "unittest.hpp"
+#include <pthread.h>
+
+void
+ut_pthread_create(pthread_t *thread, const pthread_attr_t *attr,
+		  void *(*start_routine)(void *), void *arg)
+{
+	if (pthread_create(thread, attr, start_routine, arg) != 0)
+		UT_FATAL("pthread_create failed");
+}
+
+void
+ut_pthread_join(pthread_t *thread, void **value)
+{
+	if (pthread_join(*thread, value) != 0)
+		UT_FATAL("pthread_join failed");
+}
+
+#endif /* PMEMSTREAM_PTHREAD_COMMON_HPP */

--- a/tests/common/test_backtrace.c
+++ b/tests/common/test_backtrace.c
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2015-2021, Intel Corporation */
+
+/*
+ * backtrace.c -- backtrace reporting routines
+ */
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include "test_backtrace.h"
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef USE_LIBUNWIND
+
+#define UNW_LOCAL_ONLY
+#include <dlfcn.h>
+#include <libunwind.h>
+
+#define PROCNAMELEN 256
+/*
+ * test_dump_backtrace -- dump stacktrace to error log using libunwind
+ */
+void test_dump_backtrace(void)
+{
+	unw_context_t context;
+	unw_proc_info_t pip;
+
+	pip.unwind_info = NULL;
+	int ret = unw_getcontext(&context);
+	if (ret) {
+		fprintf(stderr, "unw_getcontext: %s [%d]\n", unw_strerror(ret), ret);
+		return;
+	}
+
+	unw_cursor_t cursor;
+	ret = unw_init_local(&cursor, &context);
+	if (ret) {
+		fprintf(stderr, "unw_init_local: %s [%d]\n", unw_strerror(ret), ret);
+		return;
+	}
+
+	ret = unw_step(&cursor);
+
+	char procname[PROCNAMELEN];
+	unsigned i = 0;
+
+	while (ret > 0) {
+		ret = unw_get_proc_info(&cursor, &pip);
+		if (ret) {
+			fprintf(stderr, "[%u] unw_get_proc_info: %s [%d]\n", i,
+				unw_strerror(ret), ret);
+			break;
+		}
+
+		unw_word_t off;
+		ret = unw_get_proc_name(&cursor, procname, PROCNAMELEN, &off);
+		if (ret && ret != -UNW_ENOMEM) {
+			if (ret != -UNW_EUNSPEC) {
+				fprintf(stderr, "[%u] unw_get_proc_name: %s [%d]\n", i,
+					unw_strerror(ret), ret);
+			}
+
+			strcpy(procname, "?");
+		}
+
+		void *ptr = (void *)(pip.start_ip + off);
+		Dl_info dlinfo;
+		const char *fname = "?";
+
+		if (dladdr(ptr, &dlinfo) && dlinfo.dli_fname && *dlinfo.dli_fname)
+			fname = dlinfo.dli_fname;
+
+		printf("%u: %s (%s%s+0x%lx) [%p]\n", i++, fname, procname,
+		       ret == -UNW_ENOMEM ? "..." : "", off, ptr);
+
+		ret = unw_step(&cursor);
+		if (ret < 0)
+			fprintf(stderr, "unw_step: %s [%d]\n", unw_strerror(ret), ret);
+	}
+}
+#else /* USE_LIBUNWIND */
+
+#define BSIZE 100
+
+#ifndef _WIN32
+
+#include <execinfo.h>
+
+/*
+ * test_dump_backtrace -- dump stacktrace to error log using libc's backtrace
+ */
+void test_dump_backtrace(void)
+{
+	int j, nptrs;
+	void *buffer[BSIZE];
+	char **strings;
+
+	nptrs = backtrace(buffer, BSIZE);
+
+	strings = backtrace_symbols(buffer, nptrs);
+	if (strings == NULL) {
+		fprintf(stderr, "backtrace_symbols %s\n", strerror(errno));
+		return;
+	}
+
+	for (j = 0; j < nptrs; j++)
+		printf("%u: %s\n", j, strings[j]);
+
+	free(strings);
+}
+
+#else /* _WIN32 */
+
+#include <assert.h>
+#include <tchar.h>
+#include <windows.h>
+
+#include <DbgHelp.h>
+
+/*
+ * test_dump_backtrace -- dump stacktrace to error log
+ */
+void test_dump_backtrace(void)
+{
+	void *buffer[BSIZE];
+	unsigned nptrs;
+	SYMBOL_INFO *symbol;
+
+	HANDLE proc_hndl = GetCurrentProcess();
+	SymInitialize(proc_hndl, NULL, TRUE);
+
+	nptrs = CaptureStackBackTrace(0, BSIZE, buffer, NULL);
+	symbol = calloc(sizeof(SYMBOL_INFO) + MAX_SYM_NAME * sizeof(CHAR), 1);
+	symbol->MaxNameLen = MAX_SYM_NAME - 1;
+	symbol->SizeOfStruct = sizeof(SYMBOL_INFO);
+
+	for (unsigned i = 0; i < nptrs; i++) {
+		if (SymFromAddr(proc_hndl, (DWORD64)buffer[i], 0, symbol)) {
+			printf("%u: %s [%p]\n", nptrs - i - 1, symbol->Name, buffer[i]);
+		} else {
+			printf("%u: [%p]\n", nptrs - i - 1, buffer[i]);
+		}
+	}
+
+	free(symbol);
+}
+
+#endif /* _WIN32 */
+
+#endif /* USE_LIBUNWIND */
+
+/*
+ * test_sighandler -- fatal signal handler
+ */
+void test_sighandler(int sig)
+{
+	printf("\nSignal: %s, backtrace:\n", strsignal(sig));
+	test_dump_backtrace();
+	printf("\n");
+	exit(128 + sig);
+}
+
+/*
+ * test_register_sighandlers -- register signal handlers for various fatal
+ * signals
+ */
+void test_register_sighandlers(void)
+{
+	signal(SIGSEGV, test_sighandler);
+	signal(SIGABRT, test_sighandler);
+	signal(SIGILL, test_sighandler);
+	signal(SIGFPE, test_sighandler);
+	signal(SIGINT, test_sighandler);
+#ifndef _WIN32
+	signal(SIGALRM, test_sighandler);
+	signal(SIGQUIT, test_sighandler);
+	signal(SIGBUS, test_sighandler);
+#endif
+}

--- a/tests/common/test_backtrace.h
+++ b/tests/common/test_backtrace.h
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2015-2021, Intel Corporation */
+
+#ifndef TEST_BACKTRACE_H
+#define TEST_BACKTRACE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void test_dump_backtrace(void);
+void test_sighandler(int sig);
+void test_register_sighandlers(void);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* TEST_BACKTRACE_H */

--- a/tests/common/thread_helpers.hpp
+++ b/tests/common/thread_helpers.hpp
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2020-2021, Intel Corporation */
+#ifndef PMEMSTREAM_THREAD_HELPERS_HPP
+#define PMEMSTREAM_THREAD_HELPERS_HPP
+
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+template <typename Function>
+void parallel_exec(size_t threads_number, Function f)
+{
+	std::vector<std::thread> threads;
+	threads.reserve(threads_number);
+
+	for (size_t i = 0; i < threads_number; ++i) {
+		threads.emplace_back(f, i);
+	}
+
+	for (auto &t : threads) {
+		t.join();
+	}
+}
+
+class latch {
+public:
+	latch(size_t desired) : counter(desired)
+	{
+	}
+
+	/* Returns true for the last thread arriving at the latch, false for all
+	 * other threads. */
+	bool
+	wait(std::unique_lock<std::mutex> &lock)
+	{
+		counter--;
+		if (counter > 0) {
+			cv.wait(lock, [&] { return counter == 0; });
+			return false;
+		} else {
+			/*
+			 * notify_call could be called outside of a lock
+			 * (it would perform better) but drd complains
+			 * in that case
+			 */
+			cv.notify_all();
+			return true;
+		}
+	}
+
+private:
+	std::condition_variable cv;
+	size_t counter = 0;
+};
+
+/*
+ * This function executes 'threads_number' threads and provides
+ * 'syncthreads' method (multi-use synchronization barrier) for f()
+ */
+template <typename Function>
+void
+parallel_xexec(size_t threads_number, Function f)
+{
+	std::mutex m;
+	std::shared_ptr<latch> current_latch =
+		std::shared_ptr<latch>(new latch(threads_number));
+
+	/* Implements multi-use barrier (latch). Once all threads arrive at the
+	 * latch, a new latch is allocated and used by all subsequent calls to
+	 * syncthreads. */
+	auto syncthreads = [&] {
+		std::unique_lock<std::mutex> lock(m);
+		auto l = current_latch;
+		if (l->wait(lock))
+			current_latch =
+				std::shared_ptr<latch>(new latch(threads_number));
+	};
+
+	parallel_exec(threads_number, [&](size_t tid) { f(tid, syncthreads); });
+}
+
+/*
+ * This function executes 'threads_number' threads and wait for all of them to
+ * finish executing f before calling join().
+ */
+template <typename Function>
+void
+parallel_exec_with_sync(size_t threads_number, Function f)
+{
+	parallel_xexec(threads_number,
+		       [&](size_t tid, std::function<void(void)> syncthreads) {
+			       f(tid);
+
+			       syncthreads();
+		       });
+}
+
+#endif /* PMEMSTREAM_THREAD_HELPERS_HPP */

--- a/tests/common/unittest.h
+++ b/tests/common/unittest.h
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2020-2021, Intel Corporation */
+
+#ifndef PMEMSTREAM_UNITTEST_H
+#define PMEMSTREAM_UNITTEST_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "libpmemstream.h"
+#include "test_backtrace.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <libpmem2.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+/* XXX: refactor to use __start (https://stackoverflow.com/questions/15919356/c-program-start) */
+#define START() test_register_sighandlers()
+
+static inline void UT_OUT(const char *format, ...)
+{
+	va_list args_list;
+	va_start(args_list, format);
+	vfprintf(stdout, format, args_list);
+	va_end(args_list);
+
+	fprintf(stdout, "\n");
+}
+
+static inline void UT_FATAL(const char *format, ...)
+{
+	va_list args_list;
+	va_start(args_list, format);
+	vfprintf(stderr, format, args_list);
+	va_end(args_list);
+
+	fprintf(stderr, "\n");
+
+	abort();
+}
+
+// XXX: use pmemstream_errormsg()
+/* assert a condition is true at runtime */
+#define UT_ASSERT(cnd)                                                                   \
+	((void)((cnd) ||                                                                 \
+		(UT_FATAL("%s:%d %s - assertion failure: %s, errormsg: %s", __FILE__,    \
+			  __LINE__, __func__, #cnd, pmem2_errormsg()),                  \
+		 0)))
+
+// XXX: use pmemstream_errormsg()
+/* assertion with extra info printed if assertion fails at runtime */
+#define UT_ASSERTinfo(cnd, info)                                                         \
+	((void)((cnd) ||                                                                 \
+		(UT_FATAL("%s:%d %s - assertion failure: %s (%s = %s), errormsg: %s",    \
+			  __FILE__, __LINE__, __func__, #cnd, #info, info,               \
+			  pmem2_errormsg),                                            \
+		 0)))
+
+// XXX: use pmemstream_errormsg()
+/* assert two integer values are equal at runtime */
+#define UT_ASSERTeq(lhs, rhs)                                                            \
+	((void)(((lhs) == (rhs)) ||                                                      \
+		(UT_FATAL("%s:%d %s - assertion failure: %s (0x%llx) == %s "             \
+			  "(0x%llx), errormsg: %s",                                      \
+			  __FILE__, __LINE__, __func__, #lhs, (unsigned long long)(lhs), \
+			  #rhs, (unsigned long long)(rhs), pmem2_errormsg()),           \
+		 0)))
+
+// XXX: use pmemstream_errormsg()
+/* assert two integer values are not equal at runtime */
+#define UT_ASSERTne(lhs, rhs)                                                            \
+	((void)(((lhs) != (rhs)) ||                                                      \
+		(UT_FATAL("%s:%d %s - assertion failure: %s (0x%llx) != %s "             \
+			  "(0x%llx), errormsg: %s",                                      \
+			  __FILE__, __LINE__, __func__, #lhs, (unsigned long long)(lhs), \
+			  #rhs, (unsigned long long)(rhs), pmem2_errormsg()),           \
+		 0)))
+
+/* Creates a pmem2_map from a file path, with given size.
+ * XXX: add granularity (and FILE_MODE?) as a param
+ */
+static struct pmem2_map *
+map_open(const char *file, size_t size)
+{
+	const mode_t FILE_MODE = 0644;
+	struct pmem2_source *source;
+	struct pmem2_config *config;
+	struct pmem2_map *map = NULL;
+
+	int fd = open(file, O_CREAT|O_RDWR|O_TRUNC, FILE_MODE);
+	if (fd < 0) {
+		UT_FATAL("File creation error (errno: %d)!", errno);
+		return NULL;
+	}
+
+	if (size > 0) {
+		if (ftruncate(fd, (off_t)size) != 0)
+			goto err_fd;
+	}
+
+	if (pmem2_source_from_fd(&source, fd) != 0)
+		goto err_fd;
+
+	if (pmem2_config_new(&config) != 0)
+		goto err_config;
+
+	pmem2_config_set_required_store_granularity(config,
+						    PMEM2_GRANULARITY_PAGE);
+
+	if (pmem2_map_new(&map, config, source) != 0)
+		goto err_map;
+
+err_map:
+	pmem2_config_delete(&config);
+err_config:
+	pmem2_source_delete(&source);
+err_fd:
+	close(fd);
+
+	UT_ASSERTne(map, NULL);
+	return map;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PMEMSTREAM_UNITTEST_H */

--- a/tests/common/unittest.hpp
+++ b/tests/common/unittest.hpp
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2018-2021, Intel Corporation */
+
+#ifndef PMEMSTREAM_UNITTEST_HPP
+#define PMEMSTREAM_UNITTEST_HPP
+
+#include "unittest.h"
+
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+#include <functional>
+#include <iostream>
+#include <type_traits>
+
+static inline void UT_EXCEPTION(std::exception &e)
+{
+	std::cerr << e.what() << std::endl;
+}
+
+/* assertion with exception related string printed */
+#define UT_FATALexc(exception)                                                           \
+	((void)(UT_EXCEPTION(exception),                                                 \
+		(UT_FATAL("%s:%d %s - assertion failure", __FILE__, __LINE__, __func__), \
+		 0)))
+
+#ifdef _WIN32
+#define __PRETTY_FUNCTION__ __func__
+#endif
+#define PRINT_TEST_PARAMS                                                                \
+	do {                                                                             \
+		std::cout << "TEST: " << __PRETTY_FUNCTION__ << std::endl;               \
+	} while (0)
+
+#define STAT(path, st) ut_stat(__FILE__, __LINE__, __func__, path, st)
+
+#define UT_ASSERT_NOEXCEPT(...)                                                          \
+	static_assert(noexcept(__VA_ARGS__), "Operation must be noexcept")
+
+#define ASSERT_UNREACHABLE                                                               \
+	do {                                                                             \
+		UT_FATAL("%s:%d in function %s should never be reached", __FILE__,       \
+			 __LINE__, __func__);                                            \
+	} while (0)
+
+static inline int run_test(std::function<void()> test)
+{
+	test_register_sighandlers();
+
+	try {
+		test();
+	} catch (std::exception &e) {
+		UT_FATALexc(e);
+	} catch (...) {
+		UT_FATAL("catch(...){}");
+	}
+
+	return 0;
+}
+
+#endif /* PMEMSTREAM_UNITTEST_HPP */


### PR DESCRIPTION
with functions for finding dependencies and setting up tests (e.g. helpers for `ctest`).

It's based on the framework(s) we have in libpmemobj-cpp and pmemkv, with just a pinch of rpma's tweaks and fixes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemstream/6)
<!-- Reviewable:end -->
