### PR TITLE
Make libpmemstream linkable with c++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,8 +128,7 @@ if(USE_UBSAN)
 endif()
 if(COVERAGE)
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -coverage")
-	# XXX: add also cxx flag in tests dir?
-	# set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -coverage")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -coverage")
 endif()
 
 add_common_flag(-Wall)

--- a/src/include/libpmemstream.h
+++ b/src/include/libpmemstream.h
@@ -9,6 +9,10 @@
 #include <stdint.h>
 #include <sys/types.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct pmemstream;
 struct pmemstream_tx;
 struct pmemstream_entry_iterator;
@@ -82,4 +86,7 @@ int pmemstream_entry_iterator_next(struct pmemstream_entry_iterator *iter,
 void
 pmemstream_entry_iterator_delete(struct pmemstream_entry_iterator **iterator);
 
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
 #endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -63,3 +63,7 @@ endif()
 # ----------------------------------------------------------------- #
 build_test(stream_from_map api_c/stream_from_map.c)
 add_test_generic(NAME stream_from_map TRACERS none)
+
+# XXX: remove or re-write this test, when real TC comes up
+build_test(cpp_linkage api_c/stream_from_map.cpp)
+add_test_generic(NAME cpp_linkage TRACERS none)

--- a/tests/api_c/stream_from_map.cpp
+++ b/tests/api_c/stream_from_map.cpp
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2021, Intel Corporation */
+
+#include "unittest.hpp"
+
+/**
+ * stream_from_map - unit test for pmemstream_from_map in C++
+ * Purpose of this test is to check if it's possible to compile and link with
+ * pmemstream in C++. It may be removed when some more valuable tests are added.
+ */
+
+void test_stream_from_map(char *path, size_t file_size, size_t blk_size)
+{
+	struct pmem2_map *map = map_open(path, file_size);
+	UT_ASSERTne(map, NULL);
+
+	struct pmemstream *s = NULL;
+	pmemstream_from_map(&s, blk_size, map);
+	UT_ASSERTne(s, NULL);
+
+	pmemstream_delete(&s);
+	pmem2_map_delete(&map);
+}
+
+int main(int argc, char *argv[])
+{
+	if (argc < 2) {
+		UT_FATAL("usage: %s file-name", argv[0]);
+	}
+
+	char *path = argv[1];
+
+	return run_test([&] {
+		test_stream_from_map(path, 10240, 64);
+	});
+
+	return 0;
+}


### PR DESCRIPTION
As it's hard to create simpler test than stream_form_map I just copied
it and included unittest.hpp in it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemstream/10)
<!-- Reviewable:end -->
