### PR TITLE
Remove region_context from API

### DIFF
--- a/src/include/libpmemstream.h
+++ b/src/include/libpmemstream.h
@@ -41,15 +41,13 @@ int pmemstream_region_free(struct pmemstream *stream, struct pmemstream_region r
 
 size_t pmemstream_region_size(struct pmemstream *stream, struct pmemstream_region region);
 
-int pmemstream_region_context_new(struct pmemstream_region_context **rcontext, struct pmemstream *stream,
-				  struct pmemstream_region region);
-
-void pmemstream_region_context_delete(struct pmemstream_region_context **rcontext);
-
 // synchronously appends data buffer to the end of the transaction log space
 // fails if no space is available
-int pmemstream_append(struct pmemstream *stream, struct pmemstream_region_context *rcontext, const void *buf,
-		      size_t count, struct pmemstream_entry *entry);
+// 'entry' must provide offset where new entry is appended - it can be obtained from iterator
+// after function completes, entry->offset is incremented by count + metadata size
+// and new_entry->offset is set to original value of entry->offset
+int pmemstream_append(struct pmemstream *stream, struct pmemstream_region *region, struct pmemstream_entry *entry,
+		      const void *buf, size_t count, struct pmemstream_entry *new_entry);
 
 // returns pointer to the data of the entry
 void *pmemstream_entry_data(struct pmemstream *stream, struct pmemstream_entry entry);
@@ -70,6 +68,8 @@ void pmemstream_region_iterator_delete(struct pmemstream_region_iterator **itera
 int pmemstream_entry_iterator_new(struct pmemstream_entry_iterator **iterator, struct pmemstream *stream,
 				  struct pmemstream_region region);
 
+// if this function succeeds, entry points to a valid element in the stream, otherwise, it points to a memory
+// right after last valid entry or to a beggining of region if there are no valid entries
 int pmemstream_entry_iterator_next(struct pmemstream_entry_iterator *iter, struct pmemstream_region *region,
 				   struct pmemstream_entry *entry);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -76,4 +76,7 @@ add_test_generic(NAME cpp_linkage TRACERS none)
 if(TESTS_RAPIDCHECK)
 	build_test_ext(NAME util_popcount SRC_FILES unittest/popcount.cpp LIBS rapidcheck)
 	add_test_generic(NAME util_popcount TRACERS none)
+
+	build_test_ext(NAME append SRC_FILES unittest/append.cpp LIBS rapidcheck)
+	add_test_generic(NAME append TRACERS none SCRIPT cmake/run_with_file.cmake)
 endif()

--- a/tests/cmake/run_with_file.cmake
+++ b/tests/cmake/run_with_file.cmake
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2019-2021, Intel Corporation
+
+include(${TESTS_ROOT_DIR}/cmake/exec_functions.cmake)
+
+setup()
+
+# XXX: make this generic - replace dd and paremetrize count/bs
+execute_process(COMMAND dd if=/dev/zero of=${DIR}/testfile bs=1024 count=1048576)
+execute(${EXECUTABLE} ${DIR}/testfile)
+
+finish()

--- a/tests/common/unittest.hpp
+++ b/tests/common/unittest.hpp
@@ -11,6 +11,7 @@
 #include <cstdlib>
 #include <functional>
 #include <iostream>
+#include <memory>
 #include <type_traits>
 
 static inline void UT_EXCEPTION(std::exception &e)
@@ -79,5 +80,27 @@ struct return_check {
 
 	bool status = true;
 };
+
+auto make_pmemstream(const std::string &file, size_t block_size, size_t size)
+{
+	struct pmem2_map *map = map_open(file.c_str(), size);
+	if (map == NULL) {
+		throw std::runtime_error(pmem2_errormsg());
+	}
+
+	auto map_delete = [](struct pmem2_map *map) { pmem2_map_delete(&map); };
+	auto map_uptr = std::unique_ptr<struct pmem2_map, decltype(map_delete)>(map, map_delete);
+
+	struct pmemstream *stream;
+	int ret = pmemstream_from_map(&stream, block_size, map);
+	if (ret == -1) {
+		throw std::runtime_error("pmemstream_from_map failed");
+	}
+
+	auto stream_delete = [map_uptr = std::move(map_uptr)](struct pmemstream *stream) {
+		pmemstream_delete(&stream);
+	};
+	return std::unique_ptr<struct pmemstream, decltype(stream_delete)>(stream, std::move(stream_delete));
+}
 
 #endif /* LIBPMEMSTREAM_UNITTEST_HPP */

--- a/tests/unittest/append.cpp
+++ b/tests/unittest/append.cpp
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2021, Intel Corporation */
+
+#include <algorithm>
+#include <bitset>
+#include <cstring>
+#include <numeric>
+#include <vector>
+
+#include <rapidcheck.h>
+
+#include "unittest.hpp"
+
+static constexpr size_t stream_size = 1024 * 1024;
+
+namespace
+{
+void append_at_offset(struct pmemstream *stream, struct pmemstream_region *region, struct pmemstream_entry *offset,
+		      const std::vector<std::string> &data)
+{
+	for (const auto &e : data) {
+		auto ret = pmemstream_append(stream, region, offset, e.data(), e.size(), nullptr);
+		RC_ASSERT(ret == 0);
+	}
+}
+
+struct pmemstream_region initialize_stream_single_region(struct pmemstream *stream, size_t region_size,
+							 const std::vector<std::string> &data)
+{
+	struct pmemstream_region new_region;
+	RC_ASSERT(pmemstream_region_allocate(stream, region_size, &new_region) == 0);
+
+	struct pmemstream_entry_iterator *eiter;
+	RC_ASSERT(pmemstream_entry_iterator_new(&eiter, stream, new_region) == 0);
+
+	/* Find out offset for the first entry in region */
+	struct pmemstream_entry entry;
+	RC_ASSERT(pmemstream_entry_iterator_next(eiter, NULL, &entry) == -1);
+	pmemstream_entry_iterator_delete(&eiter);
+
+	append_at_offset(stream, &new_region, &entry, data);
+
+	return new_region;
+}
+
+std::vector<std::string> get_elements_in_region(struct pmemstream *stream, struct pmemstream_region *region)
+{
+	std::vector<std::string> result;
+
+	struct pmemstream_entry_iterator *eiter;
+	RC_ASSERT(pmemstream_entry_iterator_new(&eiter, stream, *region) == 0);
+
+	struct pmemstream_entry entry;
+	while (pmemstream_entry_iterator_next(eiter, NULL, &entry) == 0) {
+		auto data_ptr = reinterpret_cast<char *>(pmemstream_entry_data(stream, entry));
+		result.emplace_back(data_ptr, pmemstream_entry_length(stream, entry));
+	}
+
+	pmemstream_entry_iterator_delete(&eiter);
+
+	return result;
+}
+
+struct pmemstream_entry get_append_offset(struct pmemstream *stream, struct pmemstream_region *region)
+{
+	struct pmemstream_entry_iterator *eiter;
+	RC_ASSERT(pmemstream_entry_iterator_new(&eiter, stream, *region) == 0);
+
+	struct pmemstream_entry entry;
+	while (pmemstream_entry_iterator_next(eiter, NULL, &entry) == 0) {
+		/* do nothing */
+	}
+
+	pmemstream_entry_iterator_delete(&eiter);
+
+	return entry;
+}
+} // namespace
+
+int main(int argc, char *argv[])
+{
+	if (argc != 2) {
+		std::cout << "Usage: " << argv[0] << " file" << std::endl;
+		return -1;
+	}
+
+	auto file = std::string(argv[1]);
+
+	return run_test([&] {
+		return_check ret;
+
+		ret += rc::check("verify if iteration return proper elements after append",
+				 [&](const std::vector<std::string> &data, const std::vector<std::string> &extra_data) {
+					 static constexpr size_t region_size = stream_size - 16 * 1024;
+					 static constexpr size_t block_size = 4096;
+					 auto stream = make_pmemstream(file, block_size, stream_size);
+
+					 /* Allocate region and init it with data */
+					 auto region = initialize_stream_single_region(stream.get(), region_size, data);
+
+					 /* Verify that all data matches */
+					 RC_ASSERT(get_elements_in_region(stream.get(), &region) == data);
+
+					 /* Find out offset at which we can append */
+					 auto append_offset = get_append_offset(stream.get(), &region);
+					 /* Append extra_data to the end */
+					 append_at_offset(stream.get(), &region, &append_offset, extra_data);
+
+					 /* Verify if stream now holds data + extra_data */
+					 auto all_elements = get_elements_in_region(stream.get(), &region);
+					 auto extra_data_start = all_elements.begin() + static_cast<int>(data.size());
+
+					 RC_ASSERT(std::equal(all_elements.begin(), extra_data_start, data.begin()));
+					 RC_ASSERT(
+						 std::equal(extra_data_start, all_elements.end(), extra_data.begin()));
+
+					 RC_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
+				 });
+	});
+}


### PR DESCRIPTION
Instead, use pmemstream_entry to hold information about where to append
new data. Instead of dedicated method for finding that offset we might
just use iterator API. It now guarantees that after reaching end of
the data (pmemstream_iterator_next return -1), pmemstrem_entry->offset will
point to offset which can be provided to pmemstream_append.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemstream/15)
<!-- Reviewable:end -->
