### PR TITLE
Add popcount validate to iterator

### DIFF
--- a/src/libpmemstream.c
+++ b/src/libpmemstream.c
@@ -100,6 +100,15 @@ static uint64_t pmemstream_get_offset_for_span(struct pmemstream *stream, pmemst
 	return (uint64_t)((uint64_t)span - (uint64_t)stream->data->spans);
 }
 
+static int validate_entry_span(pmemstream_span_bytes *entry_span)
+{
+	struct pmemstream_span_runtime rt = pmemstream_span_get_runtime(entry_span);
+	if (rt.type == PMEMSTREAM_SPAN_ENTRY && util_popcount_memory(rt.data, rt.entry.size) == rt.entry.popcount) {
+		return 0;
+	}
+	return -1;
+}
+
 int pmemstream_from_map(struct pmemstream **stream, size_t block_size, struct pmem2_map *map)
 {
 	struct pmemstream *s = malloc(sizeof(struct pmemstream));
@@ -191,7 +200,6 @@ int pmemstream_append(struct pmemstream *stream, struct pmemstream_region *regio
 
 	pmemstream_span_bytes *entry_span = pmemstream_get_span_for_offset(stream, offset);
 	pmemstream_span_create_entry(entry_span, count, util_popcount_memory(buf, count));
-	// TODO: for popcount, we also need to make sure that the memory is zeroed - maybe it can be done by bg thread?
 
 	struct pmemstream_span_runtime entry_rt = pmemstream_span_get_runtime(entry_span);
 
@@ -295,10 +303,22 @@ int pmemstream_entry_iterator_next(struct pmemstream_entry_iterator *iter, struc
 		return -1;
 	}
 
-	// TODO: verify popcount
 	iter->offset += rt.total_size;
 
+	// XXX: check if offset is out of region
+	if (entry->offset + rt.total_size > iter->region.offset + region_rt.total_size) {
+		return -1;
+	}
 	if (rt.type == PMEMSTREAM_SPAN_ENTRY) {
+		/* Validate that entry is correct, if there is any problem, clear the data right up to the end */
+		if (validate_entry_span(entry_span) < 0) {
+			size_t metadata_size = MEMBER_SIZE(pmemstream_span_runtime, empty);
+			size_t region_end_offset = iter->region.offset + region_rt.total_size;
+			size_t remaining_size = region_end_offset - entry->offset;
+			pmemstream_span_create_empty(iter->stream, entry_span, remaining_size - metadata_size);
+			iter->stream->persist(entry_span, metadata_size);
+			return -1;
+		}
 		return 0;
 	}
 


### PR DESCRIPTION
## Solution validate

### How data look like
```sh
[kfilipek@fedora build]$ ./examples/example-01-iterate test_stream
data entry 8: 1 in region 0
data entry 32: 2 in region 0
data entry 56: 3 in region 0
data entry 80: 4 in region 0
```
Data starts at 0x58 with `08 00 00 00 00 00 00 80` (span type and its size), then 8B popcount, 8B value.
![image](https://user-images.githubusercontent.com/7746856/146572095-6f94c8b1-41a9-4ce9-a07e-ee05e791c703.png)

### Modify popcount
![image](https://user-images.githubusercontent.com/7746856/146576221-87cdf96c-b428-426c-8a20-9085edd13416.png)

### Run after modification
```sh
[kfilipek@fedora build]$ ./examples/example-01-iterate test_stream
data entry 8: 1 in region 0
data entry 32: 2 in region 0
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemstream/25)
<!-- Reviewable:end -->
