### PR TITLE
Extract reserve and write from append

### DIFF
--- a/src/include/libpmemstream.h
+++ b/src/include/libpmemstream.h
@@ -46,11 +46,32 @@ size_t pmemstream_region_size(struct pmemstream *stream, struct pmemstream_regio
 int pmemstream_get_region_context(struct pmemstream *stream, struct pmemstream_region region,
 				  struct pmemstream_region_context **ctx);
 
-/* Synchronously appends data buffer after last valid entry in region.
+/* Reserve space (for a future, custom write) of a given size, in a region at offset pointed by region_context.
+ * Entry's data have to be copied into reserved space by the user and then published using pmemstream_publish.
+ * For regular usage, pmemstream_append should be simpler and safer to use and provide better performance.
  *
  * region_context is an optional parameter which can be obtained from pmemstream_get_region_context.
- * If it's NULL, pmemstream_append will obtain region_context from its internal structures (which might
- * incur overhead).
+ * If it's NULL, it will be obtained from its internal structures (which might incur overhead).
+ * reserved_entry is updated with offset of the reserved entry.
+ * data is updated with a pointer to reserved space - this is a destination for, e.g., custom memcpy. */
+int pmemstream_reserve(struct pmemstream *stream, struct pmemstream_region region,
+		       struct pmemstream_region_context *region_context, size_t size,
+		       struct pmemstream_entry *reserved_entry, void **data);
+
+/* Publish previously custom-written entry.
+ * After calling pmemstream_reserve and writing/memcpy'ing data into a reserved_entry, it's required
+ * to call this function for setting proper entry's metadata and persist the data.
+ *
+ * *data has to hold the same data as they were written by user (e.g. in custom memcpy).
+ * size of the entry have to match the previous reservation and the actual size of the data written by user. */
+int pmemstream_publish(struct pmemstream *stream, struct pmemstream_region region, const void *data, size_t size,
+		       struct pmemstream_entry *reserved_entry);
+
+/* Synchronously appends data buffer after last valid entry in region.
+ * Fails if no space is available.
+ *
+ * region_context is an optional parameter which can be obtained from pmemstream_get_region_context.
+ * If it's NULL, it will be obtained from its internal structures (which might incur overhead).
  *
  * data is a pointer to data to be appended
  * size is size of the data to be appended

--- a/src/libpmemstream.c
+++ b/src/libpmemstream.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2021, Intel Corporation */
+/* Copyright 2021-2022, Intel Corporation */
 
 /* Implementation of public C API */
 
@@ -140,10 +140,9 @@ int pmemstream_get_region_context(struct pmemstream *stream, struct pmemstream_r
 	return region_contexts_map_get_or_create(stream->region_contexts_map, region, region_context);
 }
 
-// synchronously appends data buffer to the end of the region
-int pmemstream_append(struct pmemstream *stream, struct pmemstream_region region,
-		      struct pmemstream_region_context *region_context, const void *data, size_t size,
-		      struct pmemstream_entry *new_entry)
+int pmemstream_reserve(struct pmemstream *stream, struct pmemstream_region region,
+		       struct pmemstream_region_context *region_context, size_t size,
+		       struct pmemstream_entry *reserved_entry, void **data_addr)
 {
 	size_t entry_total_size = size + SPAN_ENTRY_METADATA_SIZE;
 	size_t entry_total_size_span_aligned = ALIGN_UP(entry_total_size, sizeof(span_bytes));
@@ -175,11 +174,48 @@ int pmemstream_append(struct pmemstream *stream, struct pmemstream_region region
 		return -1;
 	}
 
-	if (new_entry) {
-		new_entry->offset = offset;
+	reserved_entry->offset = offset;
+	/* data are right next after the entry metadata */
+	*data_addr = span_offset_to_span_ptr(stream, offset + SPAN_ENTRY_METADATA_SIZE);
+
+	return ret;
+}
+
+static int pmemstream_internal_publish(struct pmemstream *stream, struct pmemstream_region region, const void *data,
+				       size_t size, struct pmemstream_entry *reserved_entry, int flags)
+{
+	span_create_entry(stream, reserved_entry->offset, data, size, util_popcount_memory(data, size), flags);
+
+	return 0;
+}
+
+int pmemstream_publish(struct pmemstream *stream, struct pmemstream_region region, const void *data, size_t size,
+		       struct pmemstream_entry *reserved_entry)
+{
+	return pmemstream_internal_publish(stream, region, data, size, reserved_entry, PMEMSTREAM_PUBLISH_PERSIST);
+}
+
+// synchronously appends data buffer to the end of the region
+int pmemstream_append(struct pmemstream *stream, struct pmemstream_region region,
+		      struct pmemstream_region_context *region_context, const void *data, size_t size,
+		      struct pmemstream_entry *new_entry)
+{
+	struct pmemstream_entry reserved_entry;
+	void *reserved_dest;
+	int ret = pmemstream_reserve(stream, region, region_context, size, &reserved_entry, &reserved_dest);
+	if (ret) {
+		return ret;
 	}
 
-	span_create_entry(stream, offset, data, size, util_popcount_memory(data, size));
+	stream->memcpy(reserved_dest, data, size, PMEM2_F_MEM_NONTEMPORAL);
+	ret = pmemstream_internal_publish(stream, region, data, size, &reserved_entry, PMEMSTREAM_PUBLISH_NOFLUSH_DATA);
+	if (ret) {
+		return ret;
+	}
+
+	if (new_entry) {
+		new_entry->offset = reserved_entry.offset;
+	}
 
 	return 0;
 }

--- a/src/libpmemstream.map
+++ b/src/libpmemstream.map
@@ -18,6 +18,8 @@ LIBPMEMSTREAM_1.0 {
 		pmemstream_region_iterator_next;
 		pmemstream_region_size;
 		pmemstream_append;
+		pmemstream_publish;
+		pmemstream_reserve;
 		pmemstream_region_allocate;
 		pmemstream_region_free;
 	local:

--- a/src/libpmemstream_internal.h
+++ b/src/libpmemstream_internal.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2021, Intel Corporation */
+/* Copyright 2021-2022, Intel Corporation */
 
 /* Internal Header */
 
@@ -14,6 +14,12 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#define PMEMSTREAM_PUBLISH_PERSIST (0)
+#define PMEMSTREAM_PUBLISH_NOFLUSH_DATA (1 << 0)
+/* don't flush nor drain span's metadata + data while publishing;
+ * it makes sense only if a persist function is called later on. */
+#define PMEMSTREAM_PUBLISH_NOFLUSH (11 << 0)
 
 #define PMEMSTREAM_SIGNATURE ("PMEMSTREAM")
 #define PMEMSTREAM_SIGNATURE_SIZE (64)

--- a/src/span.h
+++ b/src/span.h
@@ -64,7 +64,8 @@ span_bytes *span_offset_to_span_ptr(struct pmemstream *stream, uint64_t offset);
 
 /* Those functions create appropriate span at specified offset. offset must be 8-bytes aligned. */
 void span_create_empty(struct pmemstream *stream, uint64_t offset, size_t data_size);
-void span_create_entry(struct pmemstream *stream, uint64_t offset, const void *data, size_t data_size, size_t popcount);
+void span_create_entry(struct pmemstream *stream, uint64_t offset, const void *data, size_t data_size, size_t popcount,
+		       int flags);
 void span_create_region(struct pmemstream *stream, uint64_t offset, size_t size);
 
 uint64_t span_get_size(span_bytes *span);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -87,6 +87,9 @@ add_test_generic(NAME stream_from_map TRACERS none memcheck pmemcheck drd helgri
 build_test(cpp_linkage api_c/stream_from_map.cpp)
 add_test_generic(NAME cpp_linkage TRACERS none)
 
+build_test(reserve_publish unittest/reserve_publish.cpp)
+add_test_generic(NAME reserve_publish TRACERS none memcheck pmemcheck)
+
 if(TESTS_RAPIDCHECK)
 	build_test_ext(NAME util_popcount SRC_FILES unittest/popcount.cpp LIBS rapidcheck)
 	add_test_generic(NAME util_popcount TRACERS none)

--- a/tests/common/stream_helpers.hpp
+++ b/tests/common/stream_helpers.hpp
@@ -47,6 +47,7 @@ std::vector<std::string> get_elements_in_region(struct pmemstream *stream, struc
 	return result;
 }
 
+/* XXX: extend to allow more than one extra_data vector */
 void verify(pmemstream *stream, pmemstream_region region, const std::vector<std::string> &data,
 	    const std::vector<std::string> &extra_data)
 {

--- a/tests/integrity/append_break.cpp
+++ b/tests/integrity/append_break.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2021, Intel Corporation */
+/* Copyright 2021-2022, Intel Corporation */
 
 /*
  * append_break.cpp -- pmemstream_append break - data integrity test
@@ -43,9 +43,7 @@ struct pmemstream_region init_stream_single_region(struct pmemstream *stream, si
 	UT_ASSERTeq(pmemstream_entry_iterator_next(eiter, NULL, &entry), -1);
 	pmemstream_entry_iterator_delete(&eiter);
 
-	if (data) {
-		append(stream, new_region, *data);
-	}
+	append(stream, new_region, *data);
 
 	return new_region;
 }

--- a/tests/integrity/append_break.gdb
+++ b/tests/integrity/append_break.gdb
@@ -4,23 +4,17 @@ set verbose off
 set confirm off
 set breakpoint pending on
 
-# go to memcpy in append (which is next to the second span_get_runtime)
-b pmemstream_append
+# go to memcpy in append
+b pmemstream_reserve
 r
-info break 1
-b span_create_entry
-c
-#
-# Unfortunately on some systems (various gdb ver.) there's no way to
-# jump straight to the stream->memset line, so we go there step-by-step.
-b pmemstream_offset_to_ptr
-c
+# Unfortunately on some systems (various gdb ver.) there's no way to jump straight
+# to the stream->memset line, so we go to the point with "reserved_dest" available.
+s 1
 finish
-info line
-s 5
-info line
+# reserved_dest before memcpy should be 0'ed
+print *(uint8_t *)reserved_dest
 
 # watch for memcpy take place (address offset should be >512)
-watch *((uint8_t *)dest)+600
+watch *((uint8_t *)reserved_dest)+600
 c
 q

--- a/tests/unittest/reserve_publish.cpp
+++ b/tests/unittest/reserve_publish.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2021, Intel Corporation */
+/* Copyright 2021-2022, Intel Corporation */
 
 /*
  * reserve_publish.cpp -- pmemstream_reserve and pmemstream_publish functional test.
@@ -61,6 +61,7 @@ struct pmemstream_region init_stream_single_region(struct pmemstream *stream, si
 
 	struct pmemstream_entry_iterator *eiter;
 	UT_ASSERTeq(pmemstream_entry_iterator_new(&eiter, stream, new_region), 0);
+	pmemstream_entry_iterator_delete(&eiter);
 
 	append(stream, new_region, nullptr, data);
 

--- a/tests/unittest/reserve_publish.cpp
+++ b/tests/unittest/reserve_publish.cpp
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2021, Intel Corporation */
+
+/*
+ * reserve_publish.cpp -- pmemstream_reserve and pmemstream_publish functional test.
+ *			It checks if we can reserve space for entry, write to that space, and persist it.
+ *			It's executed among "regular" appends to confirm we can mix these up.
+ */
+
+#include <cstring>
+#include <vector>
+
+#include "libpmemstream_internal.h"
+#include "unittest.hpp"
+
+static constexpr size_t FILE_SIZE = 1024ULL * 1024 * 1024;
+static constexpr size_t REGION_SIZE = FILE_SIZE - 16 * 1024;
+static constexpr size_t BLK_SIZE = 4096;
+
+namespace
+{
+/* XXX: these helper methods are copy-pasted from "append_break.cpp" test. */
+
+/* append all data in the vector at the offset (pointed by region_context) */
+void append(struct pmemstream *stream, struct pmemstream_region region,
+	    struct pmemstream_region_context *region_context, const std::vector<std::string> &data)
+{
+	for (const auto &e : data) {
+		auto ret = pmemstream_append(stream, region, region_context, e.data(), e.size(), nullptr);
+		UT_ASSERTeq(ret, 0);
+	}
+}
+
+/* Reserve space, write data, and publish (persist) them, within the given region.
+ * Do this for all data in the vector. */
+void reserve_and_publish(struct pmemstream *stream, struct pmemstream_region region,
+			 const std::vector<std::string> &data_to_write)
+{
+	for (const auto &d : data_to_write) {
+		/* reserve space for given data */
+		struct pmemstream_entry reserved_entry;
+		void *reserved_data;
+		int ret = pmemstream_reserve(stream, region, nullptr, d.size(), &reserved_entry, &reserved_data);
+		UT_ASSERTeq(ret, 0);
+
+		/* write into the reserved space and publish (persist) it */
+		memcpy(reserved_data, d.data(), d.size());
+
+		/* XXX: add tests as well for non-temporal memcpy and no persist */
+		ret = pmemstream_publish(stream, region, d.data(), d.size(), &reserved_entry);
+		UT_ASSERTeq(ret, 0);
+	}
+}
+
+/* initialize stream with a single region and initial data (if given) */
+struct pmemstream_region init_stream_single_region(struct pmemstream *stream, size_t region_size,
+						   const std::vector<std::string> data)
+{
+	struct pmemstream_region new_region;
+	UT_ASSERTeq(pmemstream_region_allocate(stream, region_size, &new_region), 0);
+
+	struct pmemstream_entry_iterator *eiter;
+	UT_ASSERTeq(pmemstream_entry_iterator_new(&eiter, stream, new_region), 0);
+
+	append(stream, new_region, nullptr, data);
+
+	return new_region;
+}
+
+/* read all elements in a region */
+std::vector<std::string> get_elements_in_region(struct pmemstream *stream, struct pmemstream_region *region)
+{
+	std::vector<std::string> result;
+
+	struct pmemstream_entry_iterator *eiter;
+	UT_ASSERTeq(pmemstream_entry_iterator_new(&eiter, stream, *region), 0);
+
+	struct pmemstream_entry entry;
+	while (pmemstream_entry_iterator_next(eiter, NULL, &entry) == 0) {
+		auto data = reinterpret_cast<char *>(pmemstream_entry_data(stream, entry));
+		auto data_len = pmemstream_entry_length(stream, entry);
+		result.emplace_back(data, data_len);
+	}
+
+	pmemstream_entry_iterator_delete(&eiter);
+
+	return result;
+}
+} /* namespace */
+
+static void test(int argc, char *argv[])
+{
+	if (argc != 2) {
+		UT_FATAL("usage: %s file-name", argv[0]);
+	}
+
+	const char *path = argv[1];
+	std::vector<std::string> init_data;
+	init_data.emplace_back("1");
+	init_data.emplace_back("32");
+	init_data.emplace_back("1048576");
+	/* XXX: switch to RC test and make use of generated data instead */
+
+	try {
+		/* initialize stream with a single region and "regularly" append initial data */
+		auto s = make_pmemstream(path, BLK_SIZE, FILE_SIZE);
+		auto r = init_stream_single_region(s.get(), REGION_SIZE, init_data);
+
+		std::vector<std::string> data_to_reserve;
+		data_to_reserve.emplace_back("0");
+		data_to_reserve.emplace_back("1234");
+		data_to_reserve.emplace_back("ABCDEFGHIJKL");
+		data_to_reserve.emplace_back(512, 'A');
+
+		/* reserve and publish */
+		/* XXX: make this work with property based testing - should work with regular append as well */
+		reserve_and_publish(s.get(), r, data_to_reserve);
+
+		/* add one more "regular" append */
+		std::string extra_entry(1024, 'Z');
+		int ret = pmemstream_append(s.get(), r, nullptr, extra_entry.data(), extra_entry.size(), nullptr);
+		UT_ASSERTeq(ret, 0);
+
+		/* verify count of all appended/written entries */
+		/* XXX: make use of verify() in stream_helpers */
+		auto read_elements = get_elements_in_region(s.get(), &r);
+		auto cnt = read_elements.size();
+		auto expected_cnt = init_data.size() + data_to_reserve.size() + 1;
+		UT_ASSERTeq(cnt, expected_cnt);
+
+		/* put all these entries into one vector and check if all data is written correctly */
+		init_data.insert(init_data.end(), data_to_reserve.begin(), data_to_reserve.end());
+		init_data.emplace_back(extra_entry);
+		for (size_t i = 0; i < cnt; ++i) {
+			UT_ASSERT(init_data[i] == read_elements[i]);
+		}
+	} catch (...) {
+		UT_FATAL("Something went wrong!");
+	}
+}
+
+int main(int argc, char *argv[])
+{
+	return run_test([&] { test(argc, argv); });
+}


### PR DESCRIPTION
into separate public functions.

One might want to reserve space in a region for later data writes
and in the meantime e.g. keep appending data at the end of the region.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemstream/27)
<!-- Reviewable:end -->
