### PR TITLE
Fix offset checking in pmemstream_entry_iterator_next

### DIFF
--- a/src/libpmemstream.c
+++ b/src/libpmemstream.c
@@ -310,19 +310,15 @@ int pmemstream_entry_iterator_next(struct pmemstream_entry_iterator *iter, struc
 	 */
 	assert(entry->offset + rt.total_size <= iter->region.offset + region_rt.total_size);
 
-	if (rt.type == PMEMSTREAM_SPAN_ENTRY) {
-		/* Validate that entry is correct, if there is any problem, clear the data right up to the end */
-		if (validate_entry_span(entry_span) < 0) {
-			size_t region_end_offset = iter->region.offset + region_rt.total_size;
-			size_t remaining_size = region_end_offset - entry->offset;
-			pmemstream_span_create_empty(iter->stream, entry_span,
-						     remaining_size - SPAN_EMPTY_METADATA_SIZE);
-			return -1;
-		}
-		return 0;
+	/* Validate that entry is correct, if there is any problem, clear the data right up to the end */
+	if (validate_entry_span(entry_span) < 0) {
+		size_t region_end_offset = iter->region.offset + region_rt.total_size;
+		size_t remaining_size = region_end_offset - entry->offset;
+		pmemstream_span_create_empty(iter->stream, entry_span, remaining_size - SPAN_EMPTY_METADATA_SIZE);
+		return -1;
 	}
 
-	return -1;
+	return 0;
 }
 
 void pmemstream_entry_iterator_delete(struct pmemstream_entry_iterator **iterator)

--- a/src/libpmemstream.c
+++ b/src/libpmemstream.c
@@ -299,16 +299,17 @@ int pmemstream_entry_iterator_next(struct pmemstream_entry_iterator *iter, struc
 		*region = iter->region;
 	}
 
+	/* Make sure that we didn't go beyond region. */
 	if (iter->offset >= iter->region.offset + region_rt.total_size) {
 		return -1;
 	}
 
 	iter->offset += rt.total_size;
 
-	// XXX: check if offset is out of region
-	if (entry->offset + rt.total_size > iter->region.offset + region_rt.total_size) {
-		return -1;
-	}
+	/* Verify that all metadata and data fits inside the region - this should not fail unless stream was corrupted.
+	 */
+	assert(entry->offset + rt.total_size <= iter->region.offset + region_rt.total_size);
+
 	if (rt.type == PMEMSTREAM_SPAN_ENTRY) {
 		/* Validate that entry is correct, if there is any problem, clear the data right up to the end */
 		if (validate_entry_span(entry_span) < 0) {


### PR DESCRIPTION
We only checked that entry span starts within a region. This
new check also makes sure that all the metadata are within the
region.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemstream/40)
<!-- Reviewable:end -->
