### PR TITLE
Use offsets instead of pointers everywhere

### DIFF
--- a/src/libpmemstream.c
+++ b/src/libpmemstream.c
@@ -11,8 +11,14 @@
 #include <stdlib.h>
 #include <string.h>
 
-static void pmemstream_span_create_empty(struct pmemstream *stream, pmemstream_span_bytes *span, size_t data_size)
+static uint8_t *pmemstream_offset_to_ptr(struct pmemstream *stream, size_t offset)
 {
+	return (uint8_t *)stream->data->spans + offset;
+}
+
+static void pmemstream_span_create_empty(struct pmemstream *stream, uint64_t offset, size_t data_size)
+{
+	pmemstream_span_bytes *span = (pmemstream_span_bytes *)pmemstream_offset_to_ptr(stream, offset);
 	assert((data_size & PMEMSTREAM_SPAN_TYPE_MASK) == 0);
 	span[0] = data_size | PMEMSTREAM_SPAN_EMPTY;
 
@@ -21,9 +27,10 @@ static void pmemstream_span_create_empty(struct pmemstream *stream, pmemstream_s
 	stream->persist(span, metadata_size);
 }
 
-static void pmemstream_span_create_entry(struct pmemstream *stream, pmemstream_span_bytes *span, const void *data,
-					 size_t data_size, size_t popcount)
+static void pmemstream_span_create_entry(struct pmemstream *stream, uint64_t offset, const void *data, size_t data_size,
+					 size_t popcount)
 {
+	pmemstream_span_bytes *span = (pmemstream_span_bytes *)pmemstream_offset_to_ptr(stream, offset);
 	assert((data_size & PMEMSTREAM_SPAN_TYPE_MASK) == 0);
 	span[0] = data_size | PMEMSTREAM_SPAN_ENTRY;
 	span[1] = popcount;
@@ -34,8 +41,9 @@ static void pmemstream_span_create_entry(struct pmemstream *stream, pmemstream_s
 	stream->persist(span, metadata_size);
 }
 
-static void pmemstream_span_create_region(struct pmemstream *stream, pmemstream_span_bytes *span, size_t size)
+static void pmemstream_span_create_region(struct pmemstream *stream, uint64_t offset, size_t size)
 {
+	pmemstream_span_bytes *span = (pmemstream_span_bytes *)pmemstream_offset_to_ptr(stream, offset);
 	assert((size & PMEMSTREAM_SPAN_TYPE_MASK) == 0);
 	span[0] = size | PMEMSTREAM_SPAN_REGION;
 
@@ -43,26 +51,27 @@ static void pmemstream_span_create_region(struct pmemstream *stream, pmemstream_
 	stream->persist(span, metadata_size);
 }
 
-static struct pmemstream_span_runtime pmemstream_span_get_runtime(pmemstream_span_bytes *span)
+static struct pmemstream_span_runtime pmemstream_span_get_runtime(struct pmemstream *stream, uint64_t offset)
 {
+	pmemstream_span_bytes *span = (pmemstream_span_bytes *)pmemstream_offset_to_ptr(stream, offset);
 	struct pmemstream_span_runtime sr;
 	sr.type = span[0] & PMEMSTREAM_SPAN_TYPE_MASK;
 	uint64_t extra = span[0] & PMEMSTREAM_SPAN_EXTRA_MASK;
 	switch (sr.type) {
 		case PMEMSTREAM_SPAN_EMPTY:
 			sr.empty.size = extra;
-			sr.data = ((uint8_t *)span) + SPAN_EMPTY_METADATA_SIZE;
+			sr.data_offset = offset + SPAN_EMPTY_METADATA_SIZE;
 			sr.total_size = sr.empty.size + SPAN_EMPTY_METADATA_SIZE;
 			break;
 		case PMEMSTREAM_SPAN_ENTRY:
 			sr.entry.size = extra;
 			sr.entry.popcount = span[1];
-			sr.data = ((uint8_t *)span) + SPAN_ENTRY_METADATA_SIZE;
+			sr.data_offset = offset + SPAN_ENTRY_METADATA_SIZE;
 			sr.total_size = sr.entry.size + SPAN_ENTRY_METADATA_SIZE;
 			break;
 		case PMEMSTREAM_SPAN_REGION:
 			sr.region.size = extra;
-			sr.data = ((uint8_t *)span) + SPAN_REGION_METADATA_SIZE;
+			sr.data_offset = offset + SPAN_REGION_METADATA_SIZE;
 			sr.total_size = sr.region.size + SPAN_REGION_METADATA_SIZE;
 			break;
 		default:
@@ -95,25 +104,16 @@ static void pmemstream_init(struct pmemstream *stream)
 	stream->data->header.block_size = stream->block_size;
 	stream->persist(stream->data, sizeof(struct pmemstream_data));
 
-	pmemstream_span_create_empty(stream, &stream->data->spans[0], stream->usable_size - SPAN_EMPTY_METADATA_SIZE);
+	pmemstream_span_create_empty(stream, 0, stream->usable_size - SPAN_EMPTY_METADATA_SIZE);
 
 	stream->memcpy(stream->data->header.signature, PMEMSTREAM_SIGNATURE, strlen(PMEMSTREAM_SIGNATURE), 0);
 }
 
-static pmemstream_span_bytes *pmemstream_get_span_for_offset(struct pmemstream *stream, size_t offset)
+static int validate_entry(struct pmemstream *stream, struct pmemstream_entry entry)
 {
-	return (pmemstream_span_bytes *)((uint8_t *)stream->data->spans + offset);
-}
-
-static uint64_t pmemstream_get_offset_for_span(struct pmemstream *stream, pmemstream_span_bytes *span)
-{
-	return (uint64_t)((uint64_t)span - (uint64_t)stream->data->spans);
-}
-
-static int validate_entry_span(pmemstream_span_bytes *entry_span)
-{
-	struct pmemstream_span_runtime rt = pmemstream_span_get_runtime(entry_span);
-	if (rt.type == PMEMSTREAM_SPAN_ENTRY && util_popcount_memory(rt.data, rt.entry.size) == rt.entry.popcount) {
+	struct pmemstream_span_runtime rt = pmemstream_span_get_runtime(stream, entry.offset);
+	void *entry_data = pmemstream_offset_to_ptr(stream, rt.data_offset);
+	if (rt.type == PMEMSTREAM_SPAN_ENTRY && util_popcount_memory(entry_data, rt.entry.size) == rt.entry.popcount) {
 		return 0;
 	}
 	return -1;
@@ -153,29 +153,28 @@ void pmemstream_delete(struct pmemstream **stream)
 // necessary to hold on to it and explicitly delete it.
 int pmemstream_region_allocate(struct pmemstream *stream, size_t size, struct pmemstream_region *region)
 {
-	pmemstream_span_bytes *span = pmemstream_get_span_for_offset(stream, 0);
-	struct pmemstream_span_runtime sr = pmemstream_span_get_runtime(span);
+	const uint64_t offset = 0;
+	struct pmemstream_span_runtime sr = pmemstream_span_get_runtime(stream, offset);
 
 	if (sr.type != PMEMSTREAM_SPAN_EMPTY)
 		return -1;
 
 	size = ALIGN_UP(size, stream->block_size);
 
-	pmemstream_span_create_region(stream, span, size);
-	region->offset = 0;
+	pmemstream_span_create_region(stream, offset, size);
+	region->offset = offset;
 
 	return 0;
 }
 
 int pmemstream_region_free(struct pmemstream *stream, struct pmemstream_region region)
 {
-	pmemstream_span_bytes *span = pmemstream_get_span_for_offset(stream, region.offset);
-	struct pmemstream_span_runtime sr = pmemstream_span_get_runtime(span);
+	struct pmemstream_span_runtime sr = pmemstream_span_get_runtime(stream, region.offset);
 
 	if (sr.type != PMEMSTREAM_SPAN_REGION)
 		return -1;
 
-	pmemstream_span_create_empty(stream, &span[0], stream->usable_size - SPAN_EMPTY_METADATA_SIZE);
+	pmemstream_span_create_empty(stream, 0, stream->usable_size - SPAN_EMPTY_METADATA_SIZE);
 
 	return 0;
 }
@@ -185,8 +184,7 @@ int pmemstream_append(struct pmemstream *stream, struct pmemstream_region *regio
 		      const void *buf, size_t count, struct pmemstream_entry *new_entry)
 {
 	size_t entry_total_size = count + SPAN_ENTRY_METADATA_SIZE;
-	pmemstream_span_bytes *region_span = pmemstream_get_span_for_offset(stream, region->offset);
-	struct pmemstream_span_runtime region_sr = pmemstream_span_get_runtime(region_span);
+	struct pmemstream_span_runtime region_sr = pmemstream_span_get_runtime(stream, region->offset);
 
 	size_t offset = __atomic_fetch_add(&entry->offset, entry_total_size, __ATOMIC_RELEASE);
 
@@ -195,7 +193,7 @@ int pmemstream_append(struct pmemstream *stream, struct pmemstream_region *regio
 		return -1;
 	}
 	/* offset outside of region */
-	if (offset < region->offset + SPAN_REGION_METADATA_SIZE) {
+	if (offset < region_sr.data_offset) {
 		return -1;
 	}
 
@@ -203,8 +201,7 @@ int pmemstream_append(struct pmemstream *stream, struct pmemstream_region *regio
 		new_entry->offset = offset;
 	}
 
-	pmemstream_span_bytes *entry_span = pmemstream_get_span_for_offset(stream, offset);
-	pmemstream_span_create_entry(stream, entry_span, buf, count, util_popcount_memory(buf, count));
+	pmemstream_span_create_entry(stream, offset, buf, count, util_popcount_memory(buf, count));
 
 	return 0;
 }
@@ -212,18 +209,16 @@ int pmemstream_append(struct pmemstream *stream, struct pmemstream_region *regio
 // returns pointer to the data of the entry
 void *pmemstream_entry_data(struct pmemstream *stream, struct pmemstream_entry entry)
 {
-	pmemstream_span_bytes *entry_span = pmemstream_get_span_for_offset(stream, entry.offset);
-	struct pmemstream_span_runtime entry_sr = pmemstream_span_get_runtime(entry_span);
+	struct pmemstream_span_runtime entry_sr = pmemstream_span_get_runtime(stream, entry.offset);
 	assert(entry_sr.type == PMEMSTREAM_SPAN_ENTRY);
 
-	return entry_sr.data;
+	return pmemstream_offset_to_ptr(stream, entry_sr.data_offset);
 }
 
 // returns the size of the entry
 size_t pmemstream_entry_length(struct pmemstream *stream, struct pmemstream_entry entry)
 {
-	pmemstream_span_bytes *entry_span = pmemstream_get_span_for_offset(stream, entry.offset);
-	struct pmemstream_span_runtime entry_sr = pmemstream_span_get_runtime(entry_span);
+	struct pmemstream_span_runtime entry_sr = pmemstream_span_get_runtime(stream, entry.offset);
 	assert(entry_sr.type == PMEMSTREAM_SPAN_ENTRY);
 
 	return entry_sr.entry.size;
@@ -242,12 +237,10 @@ int pmemstream_region_iterator_new(struct pmemstream_region_iterator **iterator,
 
 int pmemstream_region_iterator_next(struct pmemstream_region_iterator *it, struct pmemstream_region *region)
 {
-	pmemstream_span_bytes *region_span;
 	struct pmemstream_span_runtime region_sr;
 
 	while (it->region.offset < it->stream->usable_size) {
-		region_span = pmemstream_get_span_for_offset(it->stream, it->region.offset);
-		region_sr = pmemstream_span_get_runtime(region_span);
+		region_sr = pmemstream_span_get_runtime(it->stream, it->region.offset);
 
 		if (region_sr.type == PMEMSTREAM_SPAN_REGION) {
 			*region = it->region;
@@ -273,8 +266,9 @@ void pmemstream_region_iterator_delete(struct pmemstream_region_iterator **itera
 int pmemstream_entry_iterator_new(struct pmemstream_entry_iterator **iterator, struct pmemstream *stream,
 				  struct pmemstream_region region)
 {
+	struct pmemstream_span_runtime rt = pmemstream_span_get_runtime(stream, region.offset);
 	struct pmemstream_entry_iterator *iter = malloc(sizeof(*iter));
-	iter->offset = region.offset + SPAN_REGION_METADATA_SIZE;
+	iter->offset = rt.data_offset;
 	iter->region = region;
 	iter->stream = stream;
 
@@ -284,19 +278,16 @@ int pmemstream_entry_iterator_new(struct pmemstream_entry_iterator **iterator, s
 }
 
 int pmemstream_entry_iterator_next(struct pmemstream_entry_iterator *iter, struct pmemstream_region *region,
-				   struct pmemstream_entry *entry)
+				   struct pmemstream_entry *user_entry)
 {
-	pmemstream_span_bytes *entry_span = pmemstream_get_span_for_offset(iter->stream, iter->offset);
-	struct pmemstream_span_runtime rt = pmemstream_span_get_runtime(entry_span);
-
-	pmemstream_span_bytes *region_span = pmemstream_get_span_for_offset(iter->stream, iter->region.offset);
-	struct pmemstream_span_runtime region_rt = pmemstream_span_get_runtime(region_span);
-
-	size_t offset = pmemstream_get_offset_for_span(iter->stream, entry_span);
+	struct pmemstream_span_runtime entry_rt = pmemstream_span_get_runtime(iter->stream, iter->offset);
+	struct pmemstream_span_runtime region_rt = pmemstream_span_get_runtime(iter->stream, iter->region.offset);
+	struct pmemstream_entry entry;
+	entry.offset = iter->offset;
 
 	// XXX: add test for NULL entry
-	if (entry) {
-		entry->offset = offset;
+	if (user_entry) {
+		*user_entry = entry;
 	}
 	if (region) {
 		*region = iter->region;
@@ -307,17 +298,17 @@ int pmemstream_entry_iterator_next(struct pmemstream_entry_iterator *iter, struc
 		return -1;
 	}
 
-	iter->offset += rt.total_size;
+	iter->offset += entry_rt.total_size;
 
 	/* Verify that all metadata and data fits inside the region - this should not fail unless stream was corrupted.
 	 */
-	assert(offset + rt.total_size <= iter->region.offset + region_rt.total_size);
+	assert(entry.offset + entry_rt.total_size <= iter->region.offset + region_rt.total_size);
 
 	/* Validate that entry is correct, if there is any problem, clear the data right up to the end */
-	if (validate_entry_span(entry_span) < 0) {
+	if (validate_entry(iter->stream, entry) < 0) {
 		size_t region_end_offset = iter->region.offset + region_rt.total_size;
-		size_t remaining_size = region_end_offset - offset;
-		pmemstream_span_create_empty(iter->stream, entry_span, remaining_size - SPAN_EMPTY_METADATA_SIZE);
+		size_t remaining_size = region_end_offset - entry.offset;
+		pmemstream_span_create_empty(iter->stream, entry.offset, remaining_size - SPAN_EMPTY_METADATA_SIZE);
 		return -1;
 	}
 

--- a/src/libpmemstream_internal.h
+++ b/src/libpmemstream_internal.h
@@ -27,7 +27,7 @@ enum pmemstream_span_type {
 struct pmemstream_span_runtime {
 	enum pmemstream_span_type type;
 	size_t total_size;
-	uint8_t *data;
+	uint64_t data_offset;
 	union {
 		struct {
 			uint64_t size;


### PR DESCRIPTION
There are a lot of places where we need to know span and data offsets.
Recovering them from span pointers is tedious.

This patch replaces data pointer with data offset in pmemstream_span_runtime.
This allows us to use offsets everywhere and convert to pointers only when
needed (for memcpy or for reading the actual data). It makes the code a
little less verbose.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemstream/41)
<!-- Reviewable:end -->
