### PR TITLE
Add example to print content of stream created by 01-iterate example

### DIFF
--- a/examples/02-visual_iterator/main.cpp
+++ b/examples/02-visual_iterator/main.cpp
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2021, Intel Corporation */
+
+#include "libpmemstream.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+#include <fcntl.h>
+#include <libpmem2.h>
+#include <unistd.h>
+
+static struct pmem2_map *map_open(const char *file)
+{
+	struct pmem2_source *source;
+	struct pmem2_config *config;
+	struct pmem2_map *map = NULL;
+
+	int fd = open(file, O_RDWR);
+	if (fd < 0)
+		return NULL;
+
+	if (pmem2_source_from_fd(&source, fd) != 0)
+		goto err_fd;
+
+	if (pmem2_config_new(&config) != 0)
+		goto err_config;
+
+	pmem2_config_set_required_store_granularity(config, PMEM2_GRANULARITY_PAGE);
+
+	if (pmem2_map_new(&map, config, source) != 0)
+		goto err_map;
+
+err_map:
+	pmem2_config_delete(&config);
+err_config:
+	pmem2_source_delete(&source);
+err_fd:
+	close(fd);
+
+	return map;
+}
+
+struct data_entry {
+	uint64_t data;
+};
+
+using std::string;
+using std::vector;
+
+static vector<string> inner_pointers = { "├── ", "│   " };
+
+void print_help(const char* exec_filename) {
+	printf("Usage: %s file [--print-as-text]\n", exec_filename);
+}
+/**
+ * This example prints a stream from map2 source.
+ *
+ * Possible usage:
+ * ./example-01-iterate XYZ
+ * ./example-02-visual_iterator XYZ
+ */
+int main(int argc, char *argv[])
+{
+	bool values_as_text = false;
+	struct pmemstream_region region;
+
+	if (argc < 2 || argc > 3) {
+		print_help(argv[0]);
+		return -1;
+	}
+	if (argc == 3) {
+		if (string(argv[2]) != "--print-as-text") {
+			print_help(argv[0]);
+			return -1;
+		}
+		values_as_text = true;
+	}
+
+	struct pmem2_map *map = map_open(argv[1]);
+	if (map == NULL) {
+		pmem2_perror("pmem2_map");
+		return -1;
+	}
+
+	struct pmemstream *stream;
+	int ret = pmemstream_from_map(&stream, 4096, map);
+	if (ret != 0) {
+		fprintf(stderr, "pmemstream_from_map failed\n");
+		return ret;
+	}
+
+	struct pmemstream_region_iterator *riter;
+	ret = pmemstream_region_iterator_new(&riter, stream);
+	if (ret != 0) {
+		fprintf(stderr, "pmemstream_region_iterator_new failed\n");
+		return ret;
+	}
+
+	/* Iterate over all regions. */
+	size_t region_id = 0;
+	while (pmemstream_region_iterator_next(riter, &region) == 0) {
+		struct pmemstream_entry entry;
+		struct pmemstream_entry_iterator *eiter;
+		ret = pmemstream_entry_iterator_new(&eiter, stream, region);
+		if (ret == -1) {
+			fprintf(stderr, "pmemstream_entry_iterator_new failed\n");
+			return ret;
+		}
+		printf("%s region%ld: %ld bytes\n", inner_pointers[0].data(), region_id++,
+		       pmemstream_region_size(stream, region));
+
+		/* Iterate over all elements in a region and save last entry value. */
+		while (pmemstream_entry_iterator_next(eiter, NULL, &entry) == 0) {
+			auto entry_length = pmemstream_entry_length(stream, entry);
+			printf("%s%s0x%-3X %ldbytes ", inner_pointers[1].data(), inner_pointers[0].data(), (unsigned int)entry.offset, entry_length);
+
+			if (values_as_text) {
+				string entry_text(static_cast<char *>(pmemstream_entry_data(stream, entry)), entry_length);
+				printf("%s", entry_text.c_str());
+			} else {
+				auto d = static_cast<unsigned char *>(pmemstream_entry_data(stream, entry));
+				for (size_t i = 0; i < entry_length; i++) {
+					printf("%.2X ", (int)d[i]);
+				}
+			}
+			printf("\n");
+		}
+		pmemstream_entry_iterator_delete(&eiter);
+	}
+
+	pmemstream_region_iterator_delete(&riter);
+	pmemstream_delete(&stream);
+	pmem2_map_delete(&map);
+
+	return 0;
+}

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -35,3 +35,6 @@ add_check_whitespace(examples ${CMAKE_CURRENT_SOURCE_DIR}/01-iterate/*.*)
 # ----------------------------------------------------------------- #
 add_example(01-iterate 01-iterate/main.c)
 target_link_libraries(example-01-iterate ${LIBPMEM2_LIBRARIES})
+
+add_example(02-visual_iterator 02-visual_iterator/main.cpp)
+target_link_libraries(example-02-visual_iterator ${LIBPMEM2_LIBRARIES})

--- a/src/libpmemstream.c
+++ b/src/libpmemstream.c
@@ -178,6 +178,14 @@ int pmemstream_region_allocate(struct pmemstream *stream, size_t size, struct pm
 	return 0;
 }
 
+size_t pmemstream_region_size(struct pmemstream *stream, struct pmemstream_region region)
+{
+	struct pmemstream_span_runtime region_sr = pmemstream_span_get_runtime(stream, region.offset);
+	assert(region_sr.type == PMEMSTREAM_SPAN_REGION);
+
+	return region_sr.region.size;
+}
+
 int pmemstream_region_free(struct pmemstream *stream, struct pmemstream_region region)
 {
 	struct pmemstream_span_runtime sr = pmemstream_span_get_runtime(stream, region.offset);


### PR DESCRIPTION
### Print stream layout as tree view
#### How it works
![image](https://user-images.githubusercontent.com/7746856/146961545-7dd49cda-f39a-4e4f-9657-80fb5e627b03.png)

#### Prepared pmemstream
To get 2 regions I need to do same changes in hex editor.
First free block were under: `0x118`
Let's calculate new size of region0: 0x118 - 0x58 => 0xC0. 192B is a length of all entries placed in **region0**
Write value `0xC0` at address: `0x50`.
Now we need to add new region at address `0x118`, so we can copy header of region0: `0x50-0x58` (raw data: `C0 00 00 00  00 00 00 C0`) and then place new entry with calculated proper value for popcount under `0x120`:
```
08 00 00 00  00 00 00 80   -> size and type
18 00 00 00  00 00 00 00   -> popcount value calculated for data
DE AD BE EF  00 00 00 00   -> data
```

![image](https://user-images.githubusercontent.com/7746856/146964300-ce18e19d-e469-4468-838a-c1b114dd3dc6.png)

#### Print entry data as text
![image](https://user-images.githubusercontent.com/7746856/147124952-53d1864a-53ef-447e-8cf5-0334d463f9e3.png)


### Authors
Created with @karczex 

Fixes #33

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemstream/46)
<!-- Reviewable:end -->
