### PR TITLE
Move clearing region to pmemstream_reserve

### DIFF
--- a/src/include/libpmemstream.h
+++ b/src/include/libpmemstream.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2021, Intel Corporation */
+/* Copyright 2021-2022, Intel Corporation */
 
 /* Public C API header */
 
@@ -19,7 +19,7 @@ struct pmemstream;
 struct pmemstream_tx;
 struct pmemstream_entry_iterator;
 struct pmemstream_region_iterator;
-struct pmemstream_region_context;
+struct pmemstream_region_runtime;
 struct pmemstream_region {
 	uint64_t offset;
 };
@@ -41,21 +41,21 @@ int pmemstream_region_free(struct pmemstream *stream, struct pmemstream_region r
 
 size_t pmemstream_region_size(struct pmemstream *stream, struct pmemstream_region region);
 
-/* Returns pointer to pmemstream_region_context. The context is managed by libpmemstream - user does not
- * have to explicitly delete/free it. Context becomes invalid after corresponding region is freed. */
-int pmemstream_get_region_context(struct pmemstream *stream, struct pmemstream_region region,
-				  struct pmemstream_region_context **ctx);
+/* Returns pointer to pmemstream_region_runtime. The runtime is managed by libpmemstream - user does not
+ * have to explicitly delete/free it. Runtime becomes invalid after corresponding region is freed. */
+int pmemstream_get_region_runtime(struct pmemstream *stream, struct pmemstream_region region,
+				  struct pmemstream_region_runtime **runtime);
 
-/* Reserve space (for a future, custom write) of a given size, in a region at offset pointed by region_context.
+/* Reserve space (for a future, custom write) of a given size, in a region at offset pointed by region_runtime.
  * Entry's data have to be copied into reserved space by the user and then published using pmemstream_publish.
  * For regular usage, pmemstream_append should be simpler and safer to use and provide better performance.
  *
- * region_context is an optional parameter which can be obtained from pmemstream_get_region_context.
+ * region_runtime is an optional parameter which can be obtained from pmemstream_get_region_runtime.
  * If it's NULL, it will be obtained from its internal structures (which might incur overhead).
  * reserved_entry is updated with offset of the reserved entry.
  * data is updated with a pointer to reserved space - this is a destination for, e.g., custom memcpy. */
 int pmemstream_reserve(struct pmemstream *stream, struct pmemstream_region region,
-		       struct pmemstream_region_context *region_context, size_t size,
+		       struct pmemstream_region_runtime *region_runtime, size_t size,
 		       struct pmemstream_entry *reserved_entry, void **data);
 
 /* Publish previously custom-written entry.
@@ -70,7 +70,7 @@ int pmemstream_publish(struct pmemstream *stream, struct pmemstream_region regio
 /* Synchronously appends data buffer after last valid entry in region.
  * Fails if no space is available.
  *
- * region_context is an optional parameter which can be obtained from pmemstream_get_region_context.
+ * region_runtime is an optional parameter which can be obtained from pmemstream_get_region_runtime.
  * If it's NULL, it will be obtained from its internal structures (which might incur overhead).
  *
  * data is a pointer to data to be appended
@@ -80,7 +80,7 @@ int pmemstream_publish(struct pmemstream *stream, struct pmemstream_region regio
  * appended entry.
  */
 int pmemstream_append(struct pmemstream *stream, struct pmemstream_region region,
-		      struct pmemstream_region_context *region_context, const void *data, size_t size,
+		      struct pmemstream_region_runtime *region_runtime, const void *data, size_t size,
 		      struct pmemstream_entry *new_entry);
 
 // returns pointer to the data of the entry

--- a/src/iterator.c
+++ b/src/iterator.c
@@ -125,8 +125,6 @@ int pmemstream_entry_iterator_next(struct pmemstream_entry_iterator *iterator, s
 		return -1;
 	}
 
-	iterator->offset += srt.total_size;
-
 	/*
 	 * Verify that all metadata and data fits inside the region - this should not fail unless stream was corrupted.
 	 */
@@ -146,6 +144,8 @@ int pmemstream_entry_iterator_next(struct pmemstream_entry_iterator *iterator, s
 
 	/* Region is already recovered, and we did not encounter end of the data yet - span must be a valid entry */
 	assert(validate_entry(iterator->stream, entry) == 0);
+
+	iterator->offset += srt.total_size;
 
 	return 0;
 }

--- a/src/iterator.c
+++ b/src/iterator.c
@@ -61,7 +61,7 @@ int entry_iterator_initialize(struct pmemstream_entry_iterator *iterator, struct
 	iter.region = region;
 	iter.stream = stream;
 
-	int ret = region_contexts_map_get_or_create(stream->region_contexts_map, region, &iter.region_context);
+	int ret = region_runtimes_map_get_or_create(stream->region_runtimes_map, region, &iter.region_runtime);
 	if (ret) {
 		return ret;
 	}
@@ -130,15 +130,15 @@ int pmemstream_entry_iterator_next(struct pmemstream_entry_iterator *iterator, s
 	 */
 	assert(entry.offset + srt.total_size <= iterator->region.offset + region_srt.total_size);
 
-	int append_offset_initialized = region_is_append_offset_initialized(iterator->region_context);
+	int initialized = region_is_runtime_initialized(iterator->region_runtime);
 
-	if (append_offset_initialized && srt.type == SPAN_EMPTY) {
+	if (initialized && srt.type == SPAN_EMPTY) {
 		/* If we found last entry and append_offset is already initialized, just return -1. */
 		return -1;
-	} else if (!append_offset_initialized && validate_entry(iterator->stream, entry) < 0) {
+	} else if (!initialized && validate_entry(iterator->stream, entry) < 0) {
 		/* If append_offset was not set yet, validate that entry is correct. If entry is not valid, set
 		 * append_offset to point to that entry. */
-		region_initialize_append_offset(iterator->region_context, entry);
+		region_runtime_initialize(iterator->region_runtime, entry);
 		return -1;
 	}
 

--- a/src/iterator.h
+++ b/src/iterator.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2021, Intel Corporation */
+/* Copyright 2021-2022, Intel Corporation */
 
 /* Internal Header */
 
@@ -17,7 +17,7 @@ extern "C" {
 struct pmemstream_entry_iterator {
 	struct pmemstream *stream;
 	struct pmemstream_region region;
-	struct pmemstream_region_context *region_context;
+	struct pmemstream_region_runtime *region_runtime;
 	uint64_t offset;
 };
 

--- a/src/libpmemstream.c
+++ b/src/libpmemstream.c
@@ -147,6 +147,14 @@ int pmemstream_get_region_context(struct pmemstream *stream, struct pmemstream_r
 	return region_contexts_map_get_or_create(stream->region_contexts_map, region, region_context);
 }
 
+static void pmemstream_clear_region_remaining(struct pmemstream *stream, struct pmemstream_region region, uint64_t tail)
+{
+	struct span_runtime region_rt = span_get_region_runtime(stream, region.offset);
+	size_t region_end_offset = region.offset + region_rt.total_size;
+	size_t remaining_size = region_end_offset - tail;
+	span_create_empty(stream, tail, remaining_size - SPAN_EMPTY_METADATA_SIZE);
+}
+
 int pmemstream_reserve(struct pmemstream *stream, struct pmemstream_region region,
 		       struct pmemstream_region_context *region_context, size_t size,
 		       struct pmemstream_entry *reserved_entry, void **data_addr)
@@ -163,16 +171,18 @@ int pmemstream_reserve(struct pmemstream *stream, struct pmemstream_region regio
 		}
 	}
 
-	ret = region_try_recover_locked(stream, region, region_context);
+	ret = region_try_initialize_append_offset_locked(stream, region, region_context);
 	if (ret) {
 		return ret;
 	}
 
-	uint64_t offset =
-		__atomic_fetch_add(&region_context->append_offset, entry_total_size_span_aligned, __ATOMIC_RELEASE);
+	uint64_t offset = __atomic_load_n(&region_context->append_offset, __ATOMIC_RELAXED);
+	if (offset & PMEMSTREAM_OFFSET_DIRTY_BIT) {
+		offset &= PMEMSTREAM_OFFSET_DIRTY_MASK;
+		pmemstream_clear_region_remaining(stream, region, offset);
+		__atomic_store_n(&region_context->append_offset, offset, __ATOMIC_RELEASE);
+	}
 
-	/* XXX: should we revert this fetch_add if no space left? What about concurrent appends? */
-	/* region overflow (no space left) or offset outside of region. */
 	if (offset + entry_total_size_span_aligned > region.offset + region_srt.total_size) {
 		return -1;
 	}
@@ -181,8 +191,10 @@ int pmemstream_reserve(struct pmemstream *stream, struct pmemstream_region regio
 		return -1;
 	}
 
+	region_context->append_offset += entry_total_size_span_aligned;
+
 	reserved_entry->offset = offset;
-	/* data are right next after the entry metadata */
+	/* data is right after the entry metadata */
 	*data_addr = span_offset_to_span_ptr(stream, offset + SPAN_ENTRY_METADATA_SIZE);
 
 	return ret;

--- a/src/libpmemstream.c
+++ b/src/libpmemstream.c
@@ -62,8 +62,8 @@ int pmemstream_from_map(struct pmemstream **stream, size_t block_size, struct pm
 		pmemstream_init(s);
 	}
 
-	s->region_contexts_map = region_contexts_map_new();
-	if (!s->region_contexts_map) {
+	s->region_runtimes_map = region_runtimes_map_new();
+	if (!s->region_runtimes_map) {
 		goto err;
 	}
 
@@ -78,7 +78,7 @@ err:
 void pmemstream_delete(struct pmemstream **stream)
 {
 	struct pmemstream *s = *stream;
-	region_contexts_map_destroy(s->region_contexts_map);
+	region_runtimes_map_destroy(s->region_runtimes_map);
 	free(s);
 	*stream = NULL;
 }
@@ -120,7 +120,7 @@ int pmemstream_region_free(struct pmemstream *stream, struct pmemstream_region r
 
 	span_create_empty(stream, 0, stream->usable_size - SPAN_EMPTY_METADATA_SIZE);
 
-	region_contexts_map_remove(stream->region_contexts_map, region);
+	region_runtimes_map_remove(stream->region_runtimes_map, region);
 
 	return 0;
 }
@@ -141,10 +141,10 @@ size_t pmemstream_entry_length(struct pmemstream *stream, struct pmemstream_entr
 	return entry_srt.entry.size;
 }
 
-int pmemstream_get_region_context(struct pmemstream *stream, struct pmemstream_region region,
-				  struct pmemstream_region_context **region_context)
+int pmemstream_get_region_runtime(struct pmemstream *stream, struct pmemstream_region region,
+				  struct pmemstream_region_runtime **region_runtime)
 {
-	return region_contexts_map_get_or_create(stream->region_contexts_map, region, region_context);
+	return region_runtimes_map_get_or_create(stream->region_runtimes_map, region, region_runtime);
 }
 
 static void pmemstream_clear_region_remaining(struct pmemstream *stream, struct pmemstream_region region, uint64_t tail)
@@ -156,7 +156,7 @@ static void pmemstream_clear_region_remaining(struct pmemstream *stream, struct 
 }
 
 int pmemstream_reserve(struct pmemstream *stream, struct pmemstream_region region,
-		       struct pmemstream_region_context *region_context, size_t size,
+		       struct pmemstream_region_runtime *region_runtime, size_t size,
 		       struct pmemstream_entry *reserved_entry, void **data_addr)
 {
 	size_t entry_total_size = size + SPAN_ENTRY_METADATA_SIZE;
@@ -164,23 +164,23 @@ int pmemstream_reserve(struct pmemstream *stream, struct pmemstream_region regio
 	struct span_runtime region_srt = span_get_region_runtime(stream, region.offset);
 	int ret = 0;
 
-	if (!region_context) {
-		ret = pmemstream_get_region_context(stream, region, &region_context);
+	if (!region_runtime) {
+		ret = pmemstream_get_region_runtime(stream, region, &region_runtime);
 		if (ret) {
 			return ret;
 		}
 	}
 
-	ret = region_try_initialize_append_offset_locked(stream, region, region_context);
+	ret = region_try_runtime_initialize_locked(stream, region, region_runtime);
 	if (ret) {
 		return ret;
 	}
 
-	uint64_t offset = __atomic_load_n(&region_context->append_offset, __ATOMIC_RELAXED);
+	uint64_t offset = __atomic_load_n(&region_runtime->append_offset, __ATOMIC_RELAXED);
 	if (offset & PMEMSTREAM_OFFSET_DIRTY_BIT) {
 		offset &= PMEMSTREAM_OFFSET_DIRTY_MASK;
 		pmemstream_clear_region_remaining(stream, region, offset);
-		__atomic_store_n(&region_context->append_offset, offset, __ATOMIC_RELEASE);
+		__atomic_store_n(&region_runtime->append_offset, offset, __ATOMIC_RELEASE);
 	}
 
 	if (offset + entry_total_size_span_aligned > region.offset + region_srt.total_size) {
@@ -191,7 +191,7 @@ int pmemstream_reserve(struct pmemstream *stream, struct pmemstream_region regio
 		return -1;
 	}
 
-	region_context->append_offset += entry_total_size_span_aligned;
+	region_runtime->append_offset += entry_total_size_span_aligned;
 
 	reserved_entry->offset = offset;
 	/* data is right after the entry metadata */
@@ -216,12 +216,12 @@ int pmemstream_publish(struct pmemstream *stream, struct pmemstream_region regio
 
 // synchronously appends data buffer to the end of the region
 int pmemstream_append(struct pmemstream *stream, struct pmemstream_region region,
-		      struct pmemstream_region_context *region_context, const void *data, size_t size,
+		      struct pmemstream_region_runtime *region_runtime, const void *data, size_t size,
 		      struct pmemstream_entry *new_entry)
 {
 	struct pmemstream_entry reserved_entry;
 	void *reserved_dest;
-	int ret = pmemstream_reserve(stream, region, region_context, size, &reserved_entry, &reserved_dest);
+	int ret = pmemstream_reserve(stream, region, region_runtime, size, &reserved_entry, &reserved_dest);
 	if (ret) {
 		return ret;
 	}

--- a/src/libpmemstream.map
+++ b/src/libpmemstream.map
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2021, Intel Corporation
+# Copyright 2021-2022, Intel Corporation
 #
 # src/libpmemstream.map -- linker map file for libpmemstream
 #
@@ -12,7 +12,7 @@ LIBPMEMSTREAM_1.0 {
 		pmemstream_entry_iterator_next;
 		pmemstream_entry_length;
 		pmemstream_from_map;
-		pmemstream_get_region_context;
+		pmemstream_get_region_runtime;
 		pmemstream_region_iterator_delete;
 		pmemstream_region_iterator_new;
 		pmemstream_region_iterator_next;

--- a/src/libpmemstream_internal.h
+++ b/src/libpmemstream_internal.h
@@ -45,7 +45,7 @@ struct pmemstream {
 	pmem2_drain_fn drain;
 	pmem2_persist_fn persist;
 
-	struct region_contexts_map *region_contexts_map;
+	struct region_runtimes_map *region_runtimes_map;
 };
 
 static inline uint8_t *pmemstream_offset_to_ptr(struct pmemstream *stream, uint64_t offset)

--- a/src/region.c
+++ b/src/region.c
@@ -8,9 +8,9 @@
 #include <assert.h>
 #include <errno.h>
 
-struct region_contexts_map *region_contexts_map_new(void)
+struct region_runtimes_map *region_runtimes_map_new(void)
 {
-	struct region_contexts_map *map = calloc(1, sizeof(*map));
+	struct region_runtimes_map *map = calloc(1, sizeof(*map));
 	if (!map) {
 		return NULL;
 	}
@@ -41,15 +41,15 @@ err_container_lock:
 	return NULL;
 }
 
-static int free_region_context_cb(uintptr_t key, void *value, void *privdata)
+static int free_region_runtime_cb(uintptr_t key, void *value, void *privdata)
 {
 	free(value);
 	return 0;
 }
 
-void region_contexts_map_destroy(struct region_contexts_map *map)
+void region_runtimes_map_destroy(struct region_runtimes_map *map)
 {
-	critnib_iter(map->container, 0, (uint64_t)-1, free_region_context_cb, NULL);
+	critnib_iter(map->container, 0, (uint64_t)-1, free_region_runtime_cb, NULL);
 	critnib_delete(map->container);
 
 	/* XXX: Handle error */
@@ -59,13 +59,13 @@ void region_contexts_map_destroy(struct region_contexts_map *map)
 	free(map);
 }
 
-int region_contexts_map_get_or_create(struct region_contexts_map *map, struct pmemstream_region region,
-				      struct pmemstream_region_context **container_handle)
+int region_runtimes_map_get_or_create(struct region_runtimes_map *map, struct pmemstream_region region,
+				      struct pmemstream_region_runtime **container_handle)
 {
-	struct pmemstream_region_context *ctx = critnib_get(map->container, region.offset);
-	if (ctx) {
+	struct pmemstream_region_runtime *runtime = critnib_get(map->container, region.offset);
+	if (runtime) {
 		if (container_handle) {
-			*container_handle = ctx;
+			*container_handle = runtime;
 		}
 		return 0;
 	}
@@ -73,41 +73,41 @@ int region_contexts_map_get_or_create(struct region_contexts_map *map, struct pm
 	int ret = -1;
 
 	pthread_mutex_lock(&map->container_lock);
-	ctx = calloc(1, sizeof(*ctx));
-	if (ctx) {
-		ret = critnib_insert(map->container, region.offset, ctx, 0 /* no update */);
+	runtime = calloc(1, sizeof(*runtime));
+	if (runtime) {
+		ret = critnib_insert(map->container, region.offset, runtime, 0 /* no update */);
 	}
 	pthread_mutex_unlock(&map->container_lock);
 
 	if (ret) {
-		/* Insert failed, free the context. */
-		free(ctx);
+		/* Insert failed, free the runtime. */
+		free(runtime);
 
 		if (ret == EEXIST) {
-			/* Someone else inserted the region context - just get a pointer to it. */
-			ctx = critnib_get(map->container, region.offset);
-			assert(ctx);
+			/* Someone else inserted the region runtime - just get a pointer to it. */
+			runtime = critnib_get(map->container, region.offset);
+			assert(runtime);
 		} else {
 			return ret;
 		}
 	}
 
 	if (container_handle) {
-		*container_handle = ctx;
+		*container_handle = runtime;
 	}
 
 	return 0;
 }
 
-void region_contexts_map_remove(struct region_contexts_map *map, struct pmemstream_region region)
+void region_runtimes_map_remove(struct region_runtimes_map *map, struct pmemstream_region region)
 {
-	struct pmemstream_region_context *ctx = critnib_remove(map->container, region.offset);
-	free(ctx);
+	struct pmemstream_region_runtime *runtime = critnib_remove(map->container, region.offset);
+	free(runtime);
 }
 
-int region_is_append_offset_initialized(struct pmemstream_region_context *region_context)
+int region_is_runtime_initialized(struct pmemstream_region_runtime *region_runtime)
 {
-	return __atomic_load_n(&region_context->append_offset, __ATOMIC_ACQUIRE) != PMEMSTREAM_OFFSET_UNINITIALIZED;
+	return __atomic_load_n(&region_runtime->append_offset, __ATOMIC_ACQUIRE) != PMEMSTREAM_OFFSET_UNINITIALIZED;
 }
 
 /* Iterates over entire region. Might initialize append_offset. */
@@ -125,33 +125,33 @@ static int region_iterate_and_try_recover(struct pmemstream *stream, struct pmem
 	return 0;
 }
 
-int region_try_initialize_append_offset_locked(struct pmemstream *stream, struct pmemstream_region region,
-					       struct pmemstream_region_context *region_context)
+int region_try_runtime_initialize_locked(struct pmemstream *stream, struct pmemstream_region region,
+					 struct pmemstream_region_runtime *region_runtime)
 {
-	assert(region_context);
+	assert(region_runtime);
 	int ret = 0;
 
 	/* If append_offset is not set, iterate over region and set it after last valid entry.
 	 * Uses "double-checked locking". */
-	if (!region_is_append_offset_initialized(region_context)) {
-		pthread_mutex_lock(&stream->region_contexts_map->region_lock);
-		if (!region_is_append_offset_initialized(region_context)) {
+	if (!region_is_runtime_initialized(region_runtime)) {
+		pthread_mutex_lock(&stream->region_runtimes_map->region_lock);
+		if (!region_is_runtime_initialized(region_runtime)) {
 			ret = region_iterate_and_try_recover(stream, region);
 		}
-		pthread_mutex_unlock(&stream->region_contexts_map->region_lock);
+		pthread_mutex_unlock(&stream->region_runtimes_map->region_lock);
 	}
 
 	return ret;
 }
 
-void region_initialize_append_offset(struct pmemstream_region_context *region_context, struct pmemstream_entry tail)
+void region_runtime_initialize(struct pmemstream_region_runtime *region_runtime, struct pmemstream_entry tail)
 {
-	assert(region_context);
+	assert(region_runtime);
 	assert(tail.offset != PMEMSTREAM_OFFSET_UNINITIALIZED);
 
 	uint64_t expected_append_offset = PMEMSTREAM_OFFSET_UNINITIALIZED;
 	uint64_t desired = tail.offset | PMEMSTREAM_OFFSET_DIRTY_BIT;
 	int weak = 0; /* Use compare_exchange int strong variation. */
-	__atomic_compare_exchange_n(&region_context->append_offset, &expected_append_offset, desired, weak,
+	__atomic_compare_exchange_n(&region_runtime->append_offset, &expected_append_offset, desired, weak,
 				    __ATOMIC_RELEASE, __ATOMIC_RELAXED);
 }

--- a/src/region.h
+++ b/src/region.h
@@ -29,11 +29,11 @@ extern "C" {
  * It contains all runtime data specific to a region.
  * It is always managed by the pmemstream (user can only obtain a non-owning pointer) and can be created
  * in few different ways:
- * - By explicitly calling pmemstream_get_region_context() for the first time
- * - By calling pmemstream_append (only if region_context does not exist yet)
- * - By advancing an entry iterator past last entry in a region (only if region_context does not exist yet)
+ * - By explicitly calling pmemstream_get_region_runtime() for the first time
+ * - By calling pmemstream_append (only if region_runtime does not exist yet)
+ * - By advancing an entry iterator past last entry in a region (only if region_runtime does not exist yet)
  */
-struct pmemstream_region_context {
+struct pmemstream_region_runtime {
 	/*
 	 * Offset at which new entries will be appended. Can be set to PMEMSTREAM_OFFSET_UNINITIALIZED.
 	 *
@@ -43,31 +43,31 @@ struct pmemstream_region_context {
 };
 
 /*
- * Holds mapping between region offset and region_context.
+ * Holds mapping between region offset and region_runtime.
  */
-struct region_contexts_map {
+struct region_runtimes_map {
 	critnib *container;
 	pthread_mutex_t container_lock;
 	pthread_mutex_t region_lock; /* XXX: for multiple regions, we might want to consider having more locks. */
 };
 
-struct region_contexts_map *region_contexts_map_new(void);
-void region_contexts_map_destroy(struct region_contexts_map *map);
+struct region_runtimes_map *region_runtimes_map_new(void);
+void region_runtimes_map_destroy(struct region_runtimes_map *map);
 
-/* Gets (or creates if missing) pointer to region_context associated with specified region. */
-int region_contexts_map_get_or_create(struct region_contexts_map *map, struct pmemstream_region region,
-				      struct pmemstream_region_context **container_handle);
+/* Gets (or creates if missing) pointer to region_runtime associated with specified region. */
+int region_runtimes_map_get_or_create(struct region_runtimes_map *map, struct pmemstream_region region,
+				      struct pmemstream_region_runtime **container_handle);
 
-void region_contexts_map_remove(struct region_contexts_map *map, struct pmemstream_region region);
+void region_runtimes_map_remove(struct region_runtimes_map *map, struct pmemstream_region region);
 
-int region_is_append_offset_initialized(struct pmemstream_region_context *region_context);
+int region_is_runtime_initialized(struct pmemstream_region_runtime *region_runtime);
 
 /* Recovers a region (under a global lock) if it is not yet recovered. */
-int region_try_initialize_append_offset_locked(struct pmemstream *stream, struct pmemstream_region region,
-					       struct pmemstream_region_context *region_context);
+int region_try_runtime_initialize_locked(struct pmemstream *stream, struct pmemstream_region region,
+					 struct pmemstream_region_runtime *region_runtime);
 
 /* Performs region recovery - initializes append_offset and clears all the data in the region after `tail` entry. */
-void region_initialize_append_offset(struct pmemstream_region_context *region_context, struct pmemstream_entry tail);
+void region_runtime_initialize(struct pmemstream_region_runtime *region_runtime, struct pmemstream_entry tail);
 
 #ifdef __cplusplus
 } /* end extern "C" */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -96,8 +96,8 @@ if(TESTS_RAPIDCHECK)
 	build_test_rc(NAME concurrent_iterate SRC_FILES unittest/concurrent_iterate.cpp)
 	add_test_generic(NAME concurrent_iterate TRACERS none)
 
-	build_test_rc(NAME get_region_context SRC_FILES unittest/get_region_context.cpp)
-	add_test_generic(NAME get_region_context TRACERS none)
+	build_test_rc(NAME get_region_runtime SRC_FILES unittest/get_region_runtime.cpp)
+	add_test_generic(NAME get_region_runtime TRACERS none)
 
 	build_test_rc(NAME create SRC_FILES unittest/create.cpp)
 	add_test_generic(NAME create TRACERS none)

--- a/tests/common/stream_helpers.hpp
+++ b/tests/common/stream_helpers.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2021, Intel Corporation */
+/* Copyright 2021-2022, Intel Corporation */
 
 #ifndef LIBPMEMSTREAM_STREAM_HELPERS_HPP
 #define LIBPMEMSTREAM_STREAM_HELPERS_HPP
@@ -10,10 +10,10 @@
 #include <vector>
 
 void append(struct pmemstream *stream, struct pmemstream_region region,
-	    struct pmemstream_region_context *region_context, const std::vector<std::string> &data)
+	    struct pmemstream_region_runtime *region_runtime, const std::vector<std::string> &data)
 {
 	for (const auto &e : data) {
-		auto ret = pmemstream_append(stream, region, region_context, e.data(), e.size(), nullptr);
+		auto ret = pmemstream_append(stream, region, region_runtime, e.data(), e.size(), nullptr);
 		RC_ASSERT(ret == 0);
 	}
 }

--- a/tests/unittest/append.cpp
+++ b/tests/unittest/append.cpp
@@ -38,8 +38,7 @@ int main(int argc, char *argv[])
 			});
 
 		ret += rc::check("verify if iteration return proper elements after pmemstream reopen",
-				 [&](const std::vector<std::string> &data, const std::vector<std::string> &extra_data,
-				     bool user_created_context) {
+				 [&](const std::vector<std::string> &data, const std::vector<std::string> &extra_data) {
 					 pmemstream_region region;
 					 {
 						 auto stream = make_pmemstream(path, TEST_DEFAULT_BLOCK_SIZE,
@@ -58,7 +57,7 @@ int main(int argc, char *argv[])
 
 		ret += rc::check("verify if iteration return proper elements after append after pmemstream reopen",
 				 [&](const std::vector<std::string> &data, const std::vector<std::string> &extra_data,
-				     bool user_created_context) {
+				     bool user_created_runtime) {
 					 pmemstream_region region;
 					 {
 						 auto stream = make_pmemstream(path, TEST_DEFAULT_BLOCK_SIZE,
@@ -70,12 +69,12 @@ int main(int argc, char *argv[])
 					 {
 						 auto stream = make_pmemstream(path, TEST_DEFAULT_BLOCK_SIZE,
 									       TEST_DEFAULT_STREAM_SIZE, false);
-						 pmemstream_region_context *ctx = NULL;
-						 if (user_created_context) {
-							 pmemstream_get_region_context(stream.get(), region, &ctx);
+						 pmemstream_region_runtime *runtime = NULL;
+						 if (user_created_runtime) {
+							 pmemstream_get_region_runtime(stream.get(), region, &runtime);
 						 }
 
-						 append(stream.get(), region, ctx, extra_data);
+						 append(stream.get(), region, runtime, extra_data);
 						 verify(stream.get(), region, data, extra_data);
 						 RC_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
 					 }

--- a/tests/unittest/get_region_runtime.cpp
+++ b/tests/unittest/get_region_runtime.cpp
@@ -24,15 +24,15 @@ int main(int argc, char *argv[])
 	return run_test([&] {
 		return_check ret;
 
-		ret += rc::check("verify pmemstream_get_region_context return the same value for all threads", [&]() {
+		ret += rc::check("verify pmemstream_get_region_runtime return the same value for all threads", [&]() {
 			const auto concurrency = *rc::gen::inRange<std::size_t>(0, max_concurrency);
 
 			auto stream = make_pmemstream(path, TEST_DEFAULT_BLOCK_SIZE, TEST_DEFAULT_STREAM_SIZE);
 			auto region = initialize_stream_single_region(stream.get(), TEST_DEFAULT_REGION_SIZE, {});
 
-			std::vector<pmemstream_region_context *> threads_data(concurrency);
+			std::vector<pmemstream_region_runtime *> threads_data(concurrency);
 			parallel_exec(concurrency, [&](size_t tid) {
-				RC_ASSERT(pmemstream_get_region_context(stream.get(), region, &threads_data[tid]) == 0);
+				RC_ASSERT(pmemstream_get_region_runtime(stream.get(), region, &threads_data[tid]) == 0);
 
 				auto is_nullptr = threads_data[tid] == nullptr;
 				RC_ASSERT(!is_nullptr);

--- a/tests/unittest/reserve_publish.cpp
+++ b/tests/unittest/reserve_publish.cpp
@@ -20,12 +20,12 @@ namespace
 {
 /* XXX: these helper methods are copy-pasted from "append_break.cpp" test. */
 
-/* append all data in the vector at the offset (pointed by region_context) */
+/* append all data in the vector at the offset (pointed by region_runtime) */
 void append(struct pmemstream *stream, struct pmemstream_region region,
-	    struct pmemstream_region_context *region_context, const std::vector<std::string> &data)
+	    struct pmemstream_region_runtime *region_runtime, const std::vector<std::string> &data)
 {
 	for (const auto &e : data) {
-		auto ret = pmemstream_append(stream, region, region_context, e.data(), e.size(), nullptr);
+		auto ret = pmemstream_append(stream, region, region_runtime, e.data(), e.size(), nullptr);
 		UT_ASSERTeq(ret, 0);
 	}
 }


### PR DESCRIPTION
With this change iterator does not have to modify any peristent data
which will be beneficial for adding multi-process support.

Also, previous implementation was racy if there was a concurrent append
and iterate. If region_recover was called in iterator, append could
start doing data memcpy before region_recover finished - data could
be oberwritten by 0s.

Also, this patch removes atomic_fetch_add on append_offset - for now
pmemstream_append/reserve can only be called from single thread anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemstream/60)
<!-- Reviewable:end -->
