### PR TITLE
Introduce id_manager module

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,7 @@ set(SOURCES critnib/critnib.c
 			iterator.c
 			region.c
 			span.c
+			thread_id.c
 			libpmemstream.c)
 
 add_library(pmemstream SHARED ${SOURCES})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020-2021, Intel Corporation
+# Copyright 2020-2022, Intel Corporation
 
 add_cppstyle(src
 	${CMAKE_CURRENT_SOURCE_DIR}/*.[chp]
@@ -14,6 +14,7 @@ add_check_whitespace(src
 	${CMAKE_CURRENT_SOURCE_DIR}/critnib/*.[chp])
 
 set(SOURCES critnib/critnib.c
+			id_manager.c
 			iterator.c
 			region.c
 			span.c

--- a/src/id_manager.c
+++ b/src/id_manager.c
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2022, Intel Corporation */
+
+#include "id_manager.h"
+#include "critnib/critnib.h"
+
+#include <assert.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+struct id_manager {
+	/* A set of all available ids between 0 and next_id.
+	 * Values are always set to NULL. We are only interested in whether
+	 * particular key exists or not. */
+	critnib *ids;
+
+	/* Minimum value bigger than all ids which reside in ids container and all
+	 * granted ids. */
+	uint64_t next_id;
+
+	/* Mutex for protecting acquiring/releasing id. */
+	pthread_mutex_t id_acquire_release_mutex;
+};
+
+struct id_manager *id_manager_new(void)
+{
+	struct id_manager *manager = malloc(sizeof(*manager));
+	if (!manager) {
+		return NULL;
+	}
+
+	manager->next_id = 0;
+
+	int ret = pthread_mutex_init(&manager->id_acquire_release_mutex, NULL);
+	if (ret) {
+		goto err_pthread_mutex_init;
+	}
+
+	manager->ids = critnib_new();
+	if (!manager->ids) {
+		goto err_critnib_new;
+	}
+
+	return manager;
+
+err_critnib_new:
+	pthread_mutex_destroy(&manager->id_acquire_release_mutex);
+err_pthread_mutex_init:
+	free(manager);
+	return NULL;
+}
+
+void id_manager_destroy(struct id_manager *manager)
+{
+	pthread_mutex_destroy(&manager->id_acquire_release_mutex);
+	critnib_delete(manager->ids);
+	free(manager);
+}
+
+static bool id_manager_critnib_get_le_key(critnib *ids, uint64_t key, uint64_t *next_key)
+{
+	void *value = NULL;
+	int found = critnib_find(ids, key, FIND_LE, next_key, &value);
+	assert(value == NULL);
+	return found;
+}
+
+static bool id_manager_critnib_get_ge_key(critnib *ids, uint64_t key, uint64_t *next_key)
+{
+	void *value = NULL;
+	int found = critnib_find(ids, key, FIND_GE, next_key, &value);
+	assert(value == NULL);
+	return found;
+}
+
+static bool id_manager_critnib_get_min_key(critnib *ids, uint64_t *key)
+{
+	return id_manager_critnib_get_ge_key(ids, 0, key);
+}
+
+static bool id_manager_critnib_get_max_key(critnib *ids, uint64_t *key)
+{
+	return id_manager_critnib_get_le_key(ids, UINT64_MAX, key);
+}
+
+uint64_t id_manager_acquire(struct id_manager *manager)
+{
+	uint64_t id;
+	pthread_mutex_lock(&manager->id_acquire_release_mutex);
+
+	uint64_t min_id;
+	bool found = id_manager_critnib_get_min_key(manager->ids, &min_id);
+	if (!found) {
+		/* No id available in ids. */
+		id = manager->next_id++;
+	} else {
+		critnib_remove(manager->ids, min_id);
+		id = min_id;
+	}
+
+	pthread_mutex_unlock(&manager->id_acquire_release_mutex);
+
+	return id;
+}
+
+static void id_manager_do_compaction(struct id_manager *manager)
+{
+	uint64_t id = manager->next_id;
+	while (1) {
+		/* Id is the biggest one from all granted ids. This means
+		 * that we can try to do compaction (decrease size of the
+		 * container and next_id value). */
+		manager->next_id--;
+
+		uint64_t next_id;
+		bool found = id_manager_critnib_get_le_key(manager->ids, id, &next_id);
+		if (!found) {
+			/* No more ids in the container. */
+			break;
+		}
+
+		id = next_id;
+		if (id == manager->next_id - 1) {
+			/* We can continue compaction. */
+			critnib_remove(manager->ids, id);
+		} else {
+			/* Cannot do compaction, some ids are still held by users. */
+			break;
+		}
+	}
+}
+
+static bool id_manager_release_invariants(struct id_manager *manager)
+{
+	uint64_t max_key;
+	bool found = id_manager_critnib_get_max_key(manager->ids, &max_key);
+	if (found) {
+		/* Otherwise compaction would have happened. */
+		return max_key < manager->next_id - 1;
+	}
+
+	return true;
+}
+
+int id_manager_release(struct id_manager *manager, uint64_t id)
+{
+	int ret = 0;
+	pthread_mutex_lock(&manager->id_acquire_release_mutex);
+
+	/* At least one id must have been granted. */
+	assert(manager->next_id >= 1);
+
+	if (id != manager->next_id - 1) {
+		ret = critnib_insert(manager->ids, id, NULL, 0);
+	} else {
+		id_manager_do_compaction(manager);
+	}
+
+	assert(id_manager_release_invariants(manager));
+	pthread_mutex_unlock(&manager->id_acquire_release_mutex);
+	return ret;
+}

--- a/src/id_manager.h
+++ b/src/id_manager.h
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2022, Intel Corporation */
+
+/* Internal Header */
+
+#ifndef LIBPMEMSTREAM_ID_MANAGER_H
+#define LIBPMEMSTREAM_ID_MANAGER_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* id_manager assigns unique ids to clients which call id_manager_acquire.
+ * Ids can be returned to id_manager (so that future clients can reuse them).
+ *
+ * Id returned to client is always lowest possible (starting from 0).
+ */
+struct id_manager;
+
+struct id_manager *id_manager_new(void);
+void id_manager_destroy(struct id_manager *manager);
+
+/* Acquires unique id with the lowest possible value. */
+uint64_t id_manager_acquire(struct id_manager *manager);
+
+/* Release id so that it can be reused by subsequent id_manager_acquire. */
+int id_manager_release(struct id_manager *manager, uint64_t id);
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+#endif /* LIBPMEMSTREAM_ID_MANAGER_H */

--- a/src/thread_id.c
+++ b/src/thread_id.c
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2021-2022, Intel Corporation */
+
+#include "thread_id.h"
+#include "id_manager.h"
+
+#include <assert.h>
+#include <pthread.h>
+#include <stdlib.h>
+
+#define THREAD_ID_INVALID UINT64_MAX
+
+/* Structure which assigns ids to threads (holds thread to id mapping). */
+struct thread_id {
+	/* Key related to per-thread 'thread_data' object. */
+	pthread_key_t key;
+
+	/* Instance of id_manager to acquire/release ids. */
+	struct id_manager *id_manager;
+
+	/* Number of threads which actively hold some 'id + 1'. Once it drops to 0,
+	 * thread_id structure is deleted. */
+	/* XXX: implement a generic refcount helper. */
+	uint64_t refcount;
+};
+
+/* This structure is kept in thread-local storage and contains per-thread id. */
+struct thread_data {
+	uint64_t id;
+	struct thread_id *key_manager;
+};
+
+static void thread_id_destructor(struct thread_id *thread_id)
+{
+	// XXX: handle errors from those functions
+	pthread_key_delete(thread_id->key);
+	id_manager_destroy(thread_id->id_manager);
+
+	free(thread_id);
+}
+
+static void id_destructor(void *data)
+{
+	struct thread_data *thread_data = (struct thread_data *)data;
+
+	/* There is no way to handle failure here - just ignore it. Failure will make
+	 * it impossible to reacquire this id but it will not affect correctness. */
+	(void)id_manager_release(thread_data->key_manager->id_manager, thread_data->id);
+
+	thread_id_destroy(thread_data->key_manager);
+
+	free(thread_data);
+}
+
+struct thread_id *thread_id_new(void)
+{
+	struct thread_id *thread_id = malloc(sizeof(*thread_id));
+	if (!thread_id) {
+		return NULL;
+	}
+
+	thread_id->id_manager = id_manager_new();
+	if (!thread_id->id_manager) {
+		goto id_manager_new_err;
+	}
+
+	int ret = pthread_key_create(&thread_id->key, id_destructor);
+	if (ret) {
+		goto key_create_err;
+	}
+
+	thread_id->refcount = 1;
+
+	return thread_id;
+
+key_create_err:
+	id_manager_destroy(thread_id->id_manager);
+id_manager_new_err:
+	free(thread_id);
+	return NULL;
+}
+
+void thread_id_destroy(struct thread_id *thread_id)
+{
+	uint64_t refcount = __atomic_sub_fetch(&thread_id->refcount, 1, __ATOMIC_RELEASE);
+	if (refcount == 0) {
+		thread_id_destructor(thread_id);
+	}
+}
+
+uint64_t thread_id_get(struct thread_id *thread_id)
+{
+	uint64_t id = THREAD_ID_INVALID;
+
+	void *td = pthread_getspecific(thread_id->key);
+	if (td == NULL) {
+		struct thread_data *thread_data = malloc(sizeof(*thread_data));
+		if (!thread_data) {
+			return THREAD_ID_INVALID;
+		}
+
+		id = id_manager_acquire(thread_id->id_manager);
+		assert(id != THREAD_ID_INVALID); // XXX: make it FATAL_ERROR
+		thread_data->id = id;
+		thread_data->key_manager = thread_id;
+
+		pthread_setspecific(thread_id->key, thread_data);
+
+		__atomic_fetch_add(&thread_id->refcount, 1, __ATOMIC_RELAXED);
+	} else {
+		id = ((struct thread_data *)td)->id;
+	}
+
+	return id;
+}

--- a/src/thread_id.h
+++ b/src/thread_id.h
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2022, Intel Corporation */
+
+/* Internal Header */
+
+#ifndef LIBPMEMSTREAM_THREAD_ID_H
+#define LIBPMEMSTREAM_THREAD_ID_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Structure which assigns ids to thread.
+ * Each thread can call thread_id_get() to obtain its unique ID (valid for the entire thread lifetime). */
+struct thread_id;
+
+struct thread_id *thread_id_new(void);
+void thread_id_destroy(struct thread_id *thread_id);
+
+/*
+ * Get this thread's unique id. Value returned by this function will not change for the entire
+ * time this thread lives. Ids returned are lowest possible (starting from 0).
+ * Once thread finished, its id can be reused by different threads.
+ *
+ * UINT64_MAX is returned on error.
+ */
+uint64_t thread_id_get(struct thread_id *thread_id);
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+#endif /* LIBPMEMSTREAM_THREAD_ID_H */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -83,6 +83,9 @@ endif()
 build_test_ext(NAME id_manager_multithreaded SRC_FILES unittest/id_manager_multithreaded.cpp ../src/id_manager.c ../src/critnib/critnib.c)
 add_test_generic(NAME id_manager_multithreaded TRACERS none memcheck drd helgrind)
 
+build_test_ext(NAME thread_id SRC_FILES unittest/thread_id.cpp ../src/id_manager.c ../src/thread_id.c ../src/critnib/critnib.c)
+add_test_generic(NAME thread_id TRACERS none memcheck drd helgrind)
+
 build_test(stream_from_map api_c/stream_from_map.c)
 add_test_generic(NAME stream_from_map TRACERS none memcheck pmemcheck drd helgrind)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -80,6 +80,9 @@ endif()
 # ----------------------------------------------------------------- #
 ## All tests
 # ----------------------------------------------------------------- #
+build_test_ext(NAME id_manager_multithreaded SRC_FILES unittest/id_manager_multithreaded.cpp ../src/id_manager.c ../src/critnib/critnib.c)
+add_test_generic(NAME id_manager_multithreaded TRACERS none memcheck drd helgrind)
+
 build_test(stream_from_map api_c/stream_from_map.c)
 add_test_generic(NAME stream_from_map TRACERS none memcheck pmemcheck drd helgrind)
 
@@ -95,6 +98,9 @@ if(TESTS_RAPIDCHECK)
 
 	build_test_rc(NAME get_region_runtime SRC_FILES unittest/get_region_runtime.cpp)
 	add_test_generic(NAME get_region_runtime TRACERS none)
+
+	build_test_rc(NAME id_manager SRC_FILES unittest/id_manager.cpp ../src/id_manager.c ../src/critnib/critnib.c)
+	add_test_generic(NAME id_manager TRACERS none memcheck)
 
 	build_test_rc(NAME reserve_publish SRC_FILES unittest/reserve_publish.cpp)
 	add_test_generic(NAME reserve_publish TRACERS none memcheck pmemcheck)

--- a/tests/common/unittest.hpp
+++ b/tests/common/unittest.hpp
@@ -125,4 +125,14 @@ auto make_pmemstream(const std::string &file, size_t block_size, size_t size, bo
 	return std::unique_ptr<struct pmemstream, decltype(stream_delete)>(stream, std::move(stream_delete));
 }
 
+/* Return function which constructs (creates unique_ptr) an instance of an object using ctor().
+ * Its main purpose is to wrap C-like interface with _new and _destroy functions in unique_ptr. */
+template <typename Ctor, typename Dtor>
+auto make_instance_ctor(Ctor &&ctor, Dtor &&dtor)
+{
+	return [&] {
+		return std::unique_ptr<std::remove_reference_t<decltype(*ctor())>, decltype(&dtor)>(ctor(), &dtor);
+	};
+}
+
 #endif /* LIBPMEMSTREAM_UNITTEST_HPP */

--- a/tests/unittest/id_manager.cpp
+++ b/tests/unittest/id_manager.cpp
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2022, Intel Corporation */
+
+/* id_manager.cpp -- verifies correctness of id_manager module */
+
+#include "id_manager.h"
+
+#include <vector>
+
+#include <rapidcheck.h>
+
+#include "thread_helpers.hpp"
+#include "unittest.hpp"
+
+namespace
+{
+static constexpr size_t max_num_id_requests = 1024;
+
+auto make_id_manager = make_instance_ctor(id_manager_new, id_manager_destroy);
+
+template <typename It>
+void release_ids(id_manager *manager, size_t size, It &&it)
+{
+	for (size_t i = 0; i < size; i++) {
+		int ret = id_manager_release(manager, *it);
+		RC_ASSERT(ret == 0);
+		++it;
+	}
+}
+
+} // namespace
+
+int main()
+{
+	return run_test([] {
+		return_check ret;
+
+		/* Verify if ids are returned in an increasing order. */
+		{
+			auto manager = make_id_manager();
+
+			for (size_t i = 0; i < max_num_id_requests; i++) {
+				auto id = id_manager_acquire(manager.get());
+				UT_ASSERT(id == i);
+			}
+		}
+
+		/* Verify if ids are reused (in case of one id being used). */
+		{
+			auto manager = make_id_manager();
+
+			for (size_t i = 0; i < max_num_id_requests; i++) {
+				auto id = id_manager_acquire(manager.get());
+				UT_ASSERT(id == 0);
+
+				int ret = id_manager_release(manager.get(), id);
+				UT_ASSERT(ret == 0);
+			}
+		}
+
+		ret += rc::check("verify if ids are reused", [](bool release_from_biggest) {
+			/* Generate a vector of acquire/release operations.
+			 * XXX: create a dedicated generator for this. */
+			static constexpr size_t max_acquire_release_ops = 1024;
+			std::vector<std::pair<unsigned, unsigned>> acquire_release;
+			size_t num_elements = *rc::gen::inRange<size_t>(1, max_num_id_requests);
+			auto gen_acq_rel = rc::gen::inRange<unsigned>(0, max_acquire_release_ops);
+			for (size_t i = 0; i < num_elements; i++) {
+				acquire_release.emplace_back(*gen_acq_rel, *gen_acq_rel);
+			}
+
+			auto manager = make_id_manager();
+			std::vector<uint64_t> acquired_ids;
+
+			for (auto &p : acquire_release) {
+				auto to_acquire = p.first;
+				auto to_release = p.second;
+
+				for (unsigned i = 0; i < to_acquire; i++) {
+					auto id = id_manager_acquire(manager.get());
+
+					/* Id will either be bigger than all existing (==
+					 * acquired_ids.size()) or will be a reused one. */
+					RC_ASSERT(id <= acquired_ids.size());
+
+					acquired_ids.emplace_back(id);
+				}
+
+				if (acquired_ids.size() < to_release)
+					to_release = acquired_ids.size();
+
+				if (release_from_biggest) {
+					release_ids(manager.get(), to_release, acquired_ids.rbegin());
+				} else {
+					release_ids(manager.get(), to_release, acquired_ids.begin());
+					/* Move remaining items into the place of released ones. */
+					std::rotate(acquired_ids.begin(),
+						    acquired_ids.begin() + static_cast<int64_t>(to_release),
+						    acquired_ids.end());
+				}
+				acquired_ids.resize(acquired_ids.size() - to_release);
+			}
+
+			if (release_from_biggest) {
+				/* Since release was always done in reverse order, all ids should be
+				 * sorted. */
+				RC_ASSERT(std::is_sorted(acquired_ids.begin(), acquired_ids.end()));
+			}
+		});
+
+		ret += rc::check("verify if reacquired ids are assigned in increasing order", []() {
+			unsigned ids_to_acquire = *rc::gen::inRange<unsigned>(0, max_num_id_requests);
+			auto manager = make_id_manager();
+			for (unsigned i = 0; i < ids_to_acquire; i++) {
+				auto id = id_manager_acquire(manager.get());
+				RC_ASSERT(id == i);
+			}
+
+			auto to_release =
+				*rc::gen::unique<std::vector<unsigned>>(rc::gen::inRange<unsigned>(0, ids_to_acquire));
+			for (auto id : to_release) {
+				RC_ASSERT(id_manager_release(manager.get(), id) == 0);
+			}
+
+			std::vector<unsigned> reacquired;
+			for (unsigned i = 0; i < to_release.size(); i++) {
+				auto id = id_manager_acquire(manager.get());
+				reacquired.push_back(id);
+			}
+
+			std::sort(to_release.begin(), to_release.end());
+			RC_ASSERT(std::equal(reacquired.begin(), reacquired.end(), to_release.begin()));
+		});
+	});
+}

--- a/tests/unittest/id_manager_multithreaded.cpp
+++ b/tests/unittest/id_manager_multithreaded.cpp
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2022, Intel Corporation */
+
+/* id_manager_multithreaded.cpp -- verifies correctness of id_manager module in multithreaded env. */
+
+#include "id_manager.h"
+
+#include <algorithm>
+#include <numeric>
+#include <vector>
+
+#include "thread_helpers.hpp"
+#include "unittest.hpp"
+
+namespace
+{
+static constexpr size_t concurrency = 24;
+
+auto make_id_manager = make_instance_ctor(id_manager_new, id_manager_destroy);
+} // namespace
+
+int main(int argc, char *argv[])
+{
+	return run_test([] {
+		/* Simple multi-threaded test. */
+
+		static constexpr size_t num_ops_per_thread_base = 16;
+		auto manager = make_id_manager();
+
+		std::vector<std::vector<uint64_t>> thread_ids(concurrency);
+		parallel_exec(concurrency, [&](size_t thread_id) {
+			auto num_ops = num_ops_per_thread_base * thread_id;
+			for (size_t i = 0; i < num_ops; i++) {
+				thread_ids[thread_id].push_back(id_manager_acquire(manager.get()));
+			}
+
+			for (auto id : thread_ids[thread_id]) {
+				int ret = id_manager_release(manager.get(), id);
+				UT_ASSERT(ret == 0);
+			}
+		});
+
+		auto merged_ids = std::accumulate(thread_ids.begin(), thread_ids.end(), std::vector<uint64_t>{},
+						  [](auto &&lhs, const auto &rhs) {
+							  lhs.insert(lhs.end(), rhs.begin(), rhs.end());
+							  return std::move(lhs);
+						  });
+		std::sort(merged_ids.begin(), merged_ids.end());
+
+		/* The id space should be contiguous. */
+		for (size_t i = 1; i < merged_ids.size(); i++) {
+			UT_ASSERT(merged_ids[i] == merged_ids[i - 1] || merged_ids[i] == merged_ids[i - 1] + 1);
+		}
+	});
+}

--- a/tests/unittest/thread_id.cpp
+++ b/tests/unittest/thread_id.cpp
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2022, Intel Corporation */
+
+/* thread_id.cpp -- verifies correctness of thread_id module */
+
+#include "thread_id.h"
+
+#include "thread_helpers.hpp"
+#include "unittest.hpp"
+
+namespace
+{
+static constexpr size_t concurrency = 128;
+
+auto make_thread_id = make_instance_ctor(thread_id_new, thread_id_destroy);
+} // namespace
+
+int main()
+{
+	return run_test([] {
+		/* verify if max thread id is not bigger than number of threads */
+		{
+			auto thread_id = make_thread_id();
+
+			std::vector<size_t> thread_data(concurrency);
+			parallel_exec(concurrency,
+				      [&](size_t id) { thread_data[id] = thread_id_get(thread_id.get()); });
+
+			std::sort(thread_data.begin(), thread_data.end());
+			UT_ASSERT(thread_data.back() <= concurrency);
+		};
+
+		/* verify if thread ids are in 0..concurrency range (when all threads are alive). */
+		{
+			auto thread_id = make_thread_id();
+
+			std::vector<size_t> threads_data(concurrency);
+			parallel_xexec(concurrency, [&](size_t id, std::function<void(void)> syncthreads) {
+				threads_data[id] = thread_id_get(thread_id.get());
+
+				syncthreads();
+
+				if (id == 0) {
+					std::sort(threads_data.begin(), threads_data.end());
+					for (size_t i = 0; i < threads_data.size(); i++) {
+						UT_ASSERTeq(threads_data[i], i);
+					}
+				}
+			});
+		}
+
+		/* verify that thread_id_get() returns the same value as long as thread lives. */
+		{
+			auto thread_id = make_thread_id();
+
+			parallel_xexec(concurrency, [&](size_t tid, std::function<void(void)> syncthreads) {
+				auto id = thread_id_get(thread_id.get());
+				UT_ASSERTeq(id, thread_id_get(thread_id.get()));
+
+				syncthreads();
+
+				UT_ASSERTeq(id, thread_id_get(thread_id.get()));
+			});
+		}
+
+		/* verify that thread ids are released after all threads die and can be reused. */
+		{
+			auto thread_id = make_thread_id();
+
+			parallel_exec(concurrency, [&](size_t id) { thread_id_get(thread_id.get()); });
+
+			UT_ASSERTeq(thread_id_get(thread_id.get()), 0);
+		}
+
+		/* verify that thread id is released after arbitrary thread dies and can be reused. */
+		{
+			/* Description:
+			 * 1. Create 'concurrency' threads and call thread_id_get in each of them.
+			 * 2. After all threads have called thread_id_get, save reference to one of them
+			 *    (arbitrary choosen one) and let this one thread finish, keep remaining threads
+			 *    alive.
+			 * 3. Wait for the arbitrary choosen thread to finish and in different thread, call
+			 *    thread_id_get. This should return the exact same id as was returned inside the
+			 *    thread which just finished.
+			 * 4. Stop all other threads.
+			 */
+			auto thread_id = make_thread_id();
+
+			static constexpr size_t thread_to_destroy_id = 45;
+			static_assert(thread_to_destroy_id < concurrency);
+
+			size_t thread_to_destroy_index = std::numeric_limits<size_t>::max();
+			std::vector<std::thread> threads;
+
+			syncthreads_barrier syncthreads(concurrency);
+			syncthreads_barrier thread_id_to_destroy_sync(2);
+			syncthreads_barrier stop_all_threads_sync(concurrency);
+			for (size_t i = 0; i < concurrency; i++) {
+				threads.emplace_back(
+					[&](size_t index) {
+						auto tid = thread_id_get(thread_id.get());
+
+						/* Wait for all threads to call thread_id_get to make sure that none of
+						 * the will reuse the id release by thread with 'id' ==
+						 * 'thread_to_destroy'. */
+						syncthreads();
+
+						if (tid == thread_to_destroy_id) {
+							/* Store it's index, notify main thread and wait for signal to
+							 * finish. */
+							thread_to_destroy_index = index;
+							thread_id_to_destroy_sync();
+						} else {
+							/* Run until notified. */
+							stop_all_threads_sync();
+						}
+					},
+					i);
+			}
+
+			/* Wait for one thread to finish. */
+			{
+				thread_id_to_destroy_sync();
+				threads[thread_to_destroy_index].join();
+			}
+
+			/* This thread should reuse the released id. */
+			std::thread new_thread(
+				[&] { UT_ASSERTeq(thread_id_get(thread_id.get()), thread_to_destroy_id); });
+			new_thread.join();
+
+			/* Stop all remaining threads. */
+			stop_all_threads_sync();
+
+			for (size_t i = 0; i < threads.size(); i++) {
+				if (threads[i].joinable())
+					threads[i].join();
+			}
+		}
+	});
+}


### PR DESCRIPTION
It can be used to assign unique ids to thread, with possibility
to reuse ids when a thread exits.

This will be handy for implementing per-thread data storage as id
can be used as an index in array.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemstream/66)
<!-- Reviewable:end -->
