### PR TITLE
span_create_entry fixes

### DIFF
--- a/src/libpmemstream.c
+++ b/src/libpmemstream.c
@@ -205,18 +205,12 @@ int pmemstream_reserve(struct pmemstream *stream, struct pmemstream_region regio
 	return ret;
 }
 
-static int pmemstream_internal_publish(struct pmemstream *stream, struct pmemstream_region region, const void *data,
-				       size_t size, struct pmemstream_entry *reserved_entry, int flags)
-{
-	span_create_entry(stream, reserved_entry->offset, size, util_popcount_memory(data, size), flags);
-
-	return 0;
-}
-
 int pmemstream_publish(struct pmemstream *stream, struct pmemstream_region region, const void *data, size_t size,
 		       struct pmemstream_entry *reserved_entry)
 {
-	return pmemstream_internal_publish(stream, region, data, size, reserved_entry, PMEMSTREAM_PUBLISH_PERSIST);
+	span_create_entry(stream, reserved_entry->offset, size, util_popcount_memory(data, size));
+
+	return 0;
 }
 
 // synchronously appends data buffer to the end of the region
@@ -232,10 +226,7 @@ int pmemstream_append(struct pmemstream *stream, struct pmemstream_region region
 	}
 
 	stream->memcpy(reserved_dest, data, size, PMEM2_F_MEM_NONTEMPORAL | PMEM2_F_MEM_NODRAIN);
-	ret = pmemstream_internal_publish(stream, region, data, size, &reserved_entry, PMEMSTREAM_PUBLISH_NOFLUSH_DATA);
-	if (ret) {
-		return ret;
-	}
+	span_create_entry_no_flush_data(stream, reserved_entry.offset, size, util_popcount_memory(data, size));
 
 	if (new_entry) {
 		new_entry->offset = reserved_entry.offset;

--- a/src/libpmemstream.c
+++ b/src/libpmemstream.c
@@ -208,7 +208,7 @@ int pmemstream_reserve(struct pmemstream *stream, struct pmemstream_region regio
 static int pmemstream_internal_publish(struct pmemstream *stream, struct pmemstream_region region, const void *data,
 				       size_t size, struct pmemstream_entry *reserved_entry, int flags)
 {
-	span_create_entry(stream, reserved_entry->offset, data, size, util_popcount_memory(data, size), flags);
+	span_create_entry(stream, reserved_entry->offset, size, util_popcount_memory(data, size), flags);
 
 	return 0;
 }

--- a/src/libpmemstream_internal.h
+++ b/src/libpmemstream_internal.h
@@ -15,12 +15,6 @@
 extern "C" {
 #endif
 
-#define PMEMSTREAM_PUBLISH_PERSIST (0)
-#define PMEMSTREAM_PUBLISH_NOFLUSH_DATA (1 << 0)
-/* don't flush nor drain span's metadata + data while publishing;
- * it makes sense only if a persist function is called later on. */
-#define PMEMSTREAM_PUBLISH_NOFLUSH (11 << 0)
-
 #define PMEMSTREAM_SIGNATURE ("PMEMSTREAM")
 #define PMEMSTREAM_SIGNATURE_SIZE (64)
 

--- a/src/span.c
+++ b/src/span.c
@@ -47,7 +47,7 @@ void span_create_entry(struct pmemstream *stream, uint64_t offset, const void *d
 	}
 
 	if (persist_size != 0) {
-		stream->persist(span, SPAN_ENTRY_METADATA_SIZE);
+		stream->persist(span, persist_size);
 	}
 }
 

--- a/src/span.c
+++ b/src/span.c
@@ -14,20 +14,24 @@ const span_bytes *span_offset_to_span_ptr(const struct pmemstream *stream, uint6
 	return (const span_bytes *)pmemstream_offset_to_ptr(stream, offset);
 }
 
-void span_create_empty(struct pmemstream *stream, uint64_t offset, size_t data_size)
+/* Creates empty span at given offset.
+ * It sets empty's type and size, and zeros out the whole span.
+ */
+void span_create_empty(struct pmemstream *stream, uint64_t offset, size_t size)
 {
 	span_bytes *span = (span_bytes *)span_offset_to_span_ptr(stream, offset);
-	assert((data_size & SPAN_TYPE_MASK) == 0);
-	span[0] = data_size | SPAN_EMPTY;
+	assert((size & SPAN_TYPE_MASK) == 0);
+	span[0] = size | SPAN_EMPTY;
 
 	void *dest = ((uint8_t *)span) + SPAN_EMPTY_METADATA_SIZE;
-	stream->memset(dest, 0, data_size, PMEM2_F_MEM_NONTEMPORAL | PMEM2_F_MEM_NODRAIN);
+	stream->memset(dest, 0, size, PMEM2_F_MEM_NONTEMPORAL | PMEM2_F_MEM_NODRAIN);
 	stream->persist(span, SPAN_EMPTY_METADATA_SIZE);
 }
 
-/* XXX: add descr
- *
+/* Creates entry span at given offset.
+ * It sets entry's metadata: type, size of the data and popcount.
  * flags may be used to adjust behavior of persisting the data; use 0 for default persist.
+ * If any data is requested to be flushed, it's followed by a drain.
  */
 void span_create_entry(struct pmemstream *stream, uint64_t offset, size_t data_size, size_t popcount, int flags)
 {
@@ -50,6 +54,9 @@ void span_create_entry(struct pmemstream *stream, uint64_t offset, size_t data_s
 	}
 }
 
+/* Creates region span at given offset.
+ * It only sets region's type and size.
+ */
 void span_create_region(struct pmemstream *stream, uint64_t offset, size_t size)
 {
 	span_bytes *span = (span_bytes *)span_offset_to_span_ptr(stream, offset);

--- a/src/span.c
+++ b/src/span.c
@@ -29,8 +29,7 @@ void span_create_empty(struct pmemstream *stream, uint64_t offset, size_t data_s
  *
  * flags may be used to adjust behavior of persisting the data; use 0 for default persist.
  */
-void span_create_entry(struct pmemstream *stream, uint64_t offset, const void *data, size_t data_size, size_t popcount,
-		       int flags)
+void span_create_entry(struct pmemstream *stream, uint64_t offset, size_t data_size, size_t popcount, int flags)
 {
 	span_bytes *span = (span_bytes *)span_offset_to_span_ptr(stream, offset);
 	assert((data_size & SPAN_TYPE_MASK) == 0);

--- a/src/span.h
+++ b/src/span.h
@@ -64,7 +64,8 @@ const span_bytes *span_offset_to_span_ptr(const struct pmemstream *stream, uint6
 
 /* Those functions create appropriate span at specified offset. offset must be 8-bytes aligned. */
 void span_create_empty(struct pmemstream *stream, uint64_t offset, size_t data_size);
-void span_create_entry(struct pmemstream *stream, uint64_t offset, size_t data_size, size_t popcount, int flags);
+void span_create_entry(struct pmemstream *stream, uint64_t offset, size_t data_size, size_t popcount);
+void span_create_entry_no_flush_data(struct pmemstream *stream, uint64_t offset, size_t data_size, size_t popcount);
 void span_create_region(struct pmemstream *stream, uint64_t offset, size_t size);
 
 uint64_t span_get_size(const span_bytes *span);

--- a/src/span.h
+++ b/src/span.h
@@ -64,8 +64,7 @@ const span_bytes *span_offset_to_span_ptr(const struct pmemstream *stream, uint6
 
 /* Those functions create appropriate span at specified offset. offset must be 8-bytes aligned. */
 void span_create_empty(struct pmemstream *stream, uint64_t offset, size_t data_size);
-void span_create_entry(struct pmemstream *stream, uint64_t offset, const void *data, size_t data_size, size_t popcount,
-		       int flags);
+void span_create_entry(struct pmemstream *stream, uint64_t offset, size_t data_size, size_t popcount, int flags);
 void span_create_region(struct pmemstream *stream, uint64_t offset, size_t size);
 
 uint64_t span_get_size(const span_bytes *span);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -97,7 +97,10 @@ if(TESTS_RAPIDCHECK)
 	add_test_generic(NAME get_region_runtime TRACERS none)
 
 	build_test_rc(NAME reserve_publish SRC_FILES unittest/reserve_publish.cpp)
-	add_test_generic(NAME reserve_publish TRACERS none memcheck pmemcheck)
+	add_test_generic(NAME reserve_publish TRACERS none memcheck)
+
+	build_test_rc(NAME reserve_publish_integrity SRC_FILES integrity/reserve_publish.cpp)
+	add_test_generic(NAME reserve_publish_integrity TRACERS none pmemcheck)
 
 	build_test_rc(NAME util_popcount SRC_FILES unittest/util_popcount.cpp)
 	add_test_generic(NAME util_popcount TRACERS none)

--- a/tests/integrity/reserve_publish.cpp
+++ b/tests/integrity/reserve_publish.cpp
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2021-2022, Intel Corporation */
+
+/*
+ * reserve_publish.cpp -- pmemstream_reserve and pmemstream_publish integrity test.
+ *			It checks if we reserve-publish approach properly writes data on pmem.
+ */
+
+#include <cstring>
+#include <vector>
+
+#include <rapidcheck.h>
+
+#include "stream_helpers.hpp"
+#include "unittest.hpp"
+
+int main(int argc, char *argv[])
+{
+	if (argc != 2) {
+		UT_FATAL("usage: %s file-path", argv[0]);
+	}
+
+	auto path = std::string(argv[1]);
+
+	return run_test([&] {
+		return_check ret;
+
+		ret += rc::check(
+			"verify if mixing reserve+publish with append works fine",
+			[&](const std::vector<std::string> &data, const std::vector<std::string> &extra_data,
+			    const bool use_append) {
+				auto stream = make_pmemstream(path, TEST_DEFAULT_BLOCK_SIZE, TEST_DEFAULT_STREAM_SIZE);
+				auto region =
+					initialize_stream_single_region(stream.get(), TEST_DEFAULT_REGION_SIZE, data);
+				verify(stream.get(), region, data, {});
+
+				reserve_and_publish(stream.get(), region, extra_data);
+
+				verify(stream.get(), region, data, extra_data);
+			});
+	});
+}

--- a/tests/unittest/reserve_publish.cpp
+++ b/tests/unittest/reserve_publish.cpp
@@ -16,30 +16,6 @@
 #include "stream_helpers.hpp"
 #include "unittest.hpp"
 
-namespace
-{
-/* Reserve space, write data, and publish (persist) them, within the given region.
- * Do this for all data in the vector. */
-void reserve_and_publish(struct pmemstream *stream, struct pmemstream_region region,
-			 const std::vector<std::string> &data_to_write)
-{
-	for (const auto &d : data_to_write) {
-		/* reserve space for given data */
-		struct pmemstream_entry reserved_entry;
-		void *reserved_data;
-		int ret = pmemstream_reserve(stream, region, nullptr, d.size(), &reserved_entry, &reserved_data);
-		RC_ASSERT(ret == 0);
-
-		/* write into the reserved space and publish (persist) it */
-		memcpy(reserved_data, d.data(), d.size());
-
-		/* XXX: add tests as well for non-temporal memcpy and no persist */
-		ret = pmemstream_publish(stream, region, d.data(), d.size(), &reserved_entry);
-		RC_ASSERT(ret == 0);
-	}
-}
-} /* namespace */
-
 int main(int argc, char *argv[])
 {
 	if (argc != 2) {


### PR DESCRIPTION
The most relevant fix, imho, is proper usage of `persist_size` in span_create_entry

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemstream/69)
<!-- Reviewable:end -->
