### PR TITLE
Add missing #include<iostream> to thread_helpers.hpp

### DIFF
--- a/tests/common/thread_helpers.hpp
+++ b/tests/common/thread_helpers.hpp
@@ -6,6 +6,7 @@
 
 #include <condition_variable>
 #include <functional>
+#include <iostream>
 #include <mutex>
 #include <thread>
 #include <vector>


### PR DESCRIPTION
It's needed by handle_exceptions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemstream/82)
<!-- Reviewable:end -->
