### PR TITLE
Fix concurrent_iterate_with_append

### DIFF
--- a/tests/unittest/concurrent_iterate_with_append.cpp
+++ b/tests/unittest/concurrent_iterate_with_append.cpp
@@ -119,7 +119,7 @@ int main(int argc, char *argv[])
 				}
 
 				auto stream = make_pmemstream(path, TEST_DEFAULT_BLOCK_SIZE, stream_size, false);
-				std::vector parallel_exec(concurrency, [&](size_t tid) {
+				parallel_exec(concurrency, [&](size_t tid) {
 					if (tid == 0) {
 						/* appender */
 						pmemstream_region_runtime *region_runtime = nullptr;


### PR DESCRIPTION
Remove unnecessary "std::vector". Instead of calling parallel_exec
the code defined vector of lambdas (concurrency was passed as size
and lambda as value to vectors ctor).

Found by coverity.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemstream/91)
<!-- Reviewable:end -->
