### PR TITLE
Fix reserve_publish example

### DIFF
--- a/examples/03_reserve_publish/main.cpp
+++ b/examples/03_reserve_publish/main.cpp
@@ -102,7 +102,7 @@ int main(int argc, char *argv[])
 	data_entry *emplaced_data = new (reserved_data) data_entry(my_entry);
 
 	/* And we have to publish, what we've written down. */
-	ret = pmemstream_publish(stream, region, emplaced_data, sizeof(data_entry), &reserved_entry);
+	ret = pmemstream_publish(stream, region, nullptr, emplaced_data, sizeof(data_entry), &reserved_entry);
 	if (ret != 0) {
 		fprintf(stderr, "pmemstream_publish failed\n");
 		return ret;


### PR DESCRIPTION
Error:
```
error: cannot convert 'data_entry*' to 'pmemstream_region_runtime*'
 ret = pmemstream_publish(stream, region, emplaced_data, sizeof(data_entry), &reserved_entry);
                                           ^~~~~~~~~~~~~
                                           |
                                           data_entry*
```