### PR TITLE
Implement C++-specific version of UT_ASSERT which throws exception

### DIFF
--- a/tests/layout/iterate_validation.cpp
+++ b/tests/layout/iterate_validation.cpp
@@ -71,7 +71,7 @@ int main(int argc, char *argv[])
 					std::vector<std::string> result;
 
 					struct pmemstream_entry_iterator *eiter;
-					RC_ASSERT(pmemstream_entry_iterator_new(&eiter, stream.get(), region) == 0);
+					UT_ASSERT(pmemstream_entry_iterator_new(&eiter, stream.get(), region) == 0);
 
 					struct pmemstream_entry entry;
 					while (pmemstream_entry_iterator_next(eiter, nullptr, &entry) == 0) {
@@ -92,8 +92,8 @@ int main(int argc, char *argv[])
 					auto stream = make_pmemstream(path, TEST_DEFAULT_BLOCK_SIZE,
 								      TEST_DEFAULT_STREAM_SIZE, false);
 					auto stream_data = get_elements_in_region(stream.get(), region);
-					RC_ASSERT(std::equal(data.begin(), data.end(), stream_data.begin()));
-					RC_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
+					UT_ASSERT(std::equal(data.begin(), data.end(), stream_data.begin()));
+					UT_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
 				}
 			});
 	});

--- a/tests/unittest/append.cpp
+++ b/tests/unittest/append.cpp
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
 				verify(stream.get(), region, data, {});
 				append(stream.get(), region, NULL, extra_data);
 				verify(stream.get(), region, data, extra_data);
-				RC_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
+				UT_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
 			});
 
 		/* verify if an entry of size = 0 can be appended and entry with size > region's size cannot */
@@ -70,22 +70,22 @@ int main(int argc, char *argv[])
 			struct pmemstream_entry ne = {0}, prev_ne = {0};
 			while (elems-- > 0) {
 				auto ret = pmemstream_append(stream.get(), region, nullptr, e.data(), e.size(), &ne);
-				RC_ASSERT(ret == 0);
-				RC_ASSERT(ne.offset > prev_ne.offset);
+				UT_ASSERT(ret == 0);
+				UT_ASSERT(ne.offset > prev_ne.offset);
 				prev_ne = ne;
 			}
 			/* next append should not fit */
 			auto ret = pmemstream_append(stream.get(), region, nullptr, e.data(), e.size(), &ne);
-			RC_ASSERT(ne.offset == prev_ne.offset);
+			UT_ASSERT(ne.offset == prev_ne.offset);
 			/* XXX: should be updated with the real error code, when available */
-			RC_ASSERT(ret == -1);
+			UT_ASSERT(ret == -1);
 			e.resize(4);
 			/* ... but smaller entry should fit just in */
 			ret = pmemstream_append(stream.get(), region, nullptr, e.data(), e.size(), &ne);
-			RC_ASSERT(ne.offset > prev_ne.offset);
-			RC_ASSERT(ret == 0);
+			UT_ASSERT(ne.offset > prev_ne.offset);
+			UT_ASSERT(ret == 0);
 
-			RC_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
+			UT_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
 		});
 
 		ret += rc::check("verify if iteration return proper elements after pmemstream reopen",
@@ -102,7 +102,7 @@ int main(int argc, char *argv[])
 						 auto stream = make_pmemstream(path, TEST_DEFAULT_BLOCK_SIZE,
 									       TEST_DEFAULT_STREAM_SIZE, false);
 						 verify(stream.get(), region, data, {});
-						 RC_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
+						 UT_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
 					 }
 				 });
 
@@ -128,7 +128,7 @@ int main(int argc, char *argv[])
 
 						 append(stream.get(), region, runtime, extra_data);
 						 verify(stream.get(), region, data, extra_data);
-						 RC_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
+						 UT_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
 					 }
 				 });
 	});

--- a/tests/unittest/concurrent_iterate.cpp
+++ b/tests/unittest/concurrent_iterate.cpp
@@ -35,8 +35,8 @@ int main(int argc, char *argv[])
 					threads_data[tid] = get_elements_in_region(stream.get(), region);
 				});
 
-				RC_ASSERT(all_of(threads_data, predicates::equal(data)));
-				RC_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
+				UT_ASSERT(all_of(threads_data, predicates::equal(data)));
+				UT_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
 			});
 
 		ret += rc::check("verify if each concurrent iteration observes the same data after stream reopen",
@@ -58,8 +58,8 @@ int main(int argc, char *argv[])
 								 get_elements_in_region(stream.get(), region);
 						 });
 
-						 RC_ASSERT(all_of(threads_data, predicates::equal(data)));
-						 RC_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
+						 UT_ASSERT(all_of(threads_data, predicates::equal(data)));
+						 UT_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
 					 }
 				 });
 	});

--- a/tests/unittest/concurrent_iterate_with_append.cpp
+++ b/tests/unittest/concurrent_iterate_with_append.cpp
@@ -23,7 +23,7 @@ void concurrent_iterate_verify(pmemstream *stream, pmemstream_region region, con
 	std::vector<std::string> result;
 
 	struct pmemstream_entry_iterator *eiter;
-	RC_ASSERT(pmemstream_entry_iterator_new(&eiter, stream, region) == 0);
+	UT_ASSERT(pmemstream_entry_iterator_new(&eiter, stream, region) == 0);
 
 	struct pmemstream_entry entry;
 
@@ -36,8 +36,8 @@ void concurrent_iterate_verify(pmemstream *stream, pmemstream_region region, con
 		}
 	}
 
-	RC_ASSERT(std::equal(data.begin(), data.end(), result.begin()));
-	RC_ASSERT(
+	UT_ASSERT(std::equal(data.begin(), data.end(), result.begin()));
+	UT_ASSERT(
 		std::equal(extra_data.begin(), extra_data.end(), result.begin() + static_cast<long long>(data.size())));
 
 	pmemstream_entry_iterator_delete(&eiter);

--- a/tests/unittest/create.cpp
+++ b/tests/unittest/create.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
 			auto region = initialize_stream_single_region(stream.get(), region_size, data);
 			verify(stream.get(), region, data, {});
 
-			RC_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
+			UT_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
 		});
 
 		ret += rc::check(
@@ -50,18 +50,18 @@ int main(int argc, char *argv[])
 
 				struct pmemstream_region_iterator *riter;
 				auto ret = pmemstream_region_iterator_new(&riter, stream.get());
-				RC_ASSERT(ret == 0);
+				UT_ASSERT(ret == 0);
 
 				struct pmemstream_region r;
 				ret = pmemstream_region_iterator_next(riter, &r);
-				RC_ASSERT(ret == 0);
-				RC_ASSERT(region.offset == r.offset);
+				UT_ASSERT(ret == 0);
+				UT_ASSERT(region.offset == r.offset);
 				/* there should be no more regions */
 				ret = pmemstream_region_iterator_next(riter, &r);
-				RC_ASSERT(ret == -1);
+				UT_ASSERT(ret == -1);
 
 				pmemstream_region_iterator_delete(&riter);
-				RC_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
+				UT_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
 			});
 
 		/* verify if a single region of size = 0 can be created */
@@ -74,15 +74,15 @@ int main(int argc, char *argv[])
 			std::string entry("ASDF");
 			auto ret =
 				pmemstream_append(stream.get(), region, nullptr, entry.data(), entry.size(), nullptr);
-			RC_ASSERT(ret != 0);
+			UT_ASSERT(ret != 0);
 
-			RC_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
+			UT_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
 		}
 
 		ret += rc::check("verify if a region of size > stream_size cannot be created", [&]() {
 			auto stream = make_pmemstream(path, TEST_DEFAULT_BLOCK_SIZE, TEST_DEFAULT_STREAM_SIZE);
 			struct pmemstream_region region;
-			RC_ASSERT(pmemstream_region_allocate(stream.get(), TEST_DEFAULT_STREAM_SIZE + 1UL, &region) !=
+			UT_ASSERT(pmemstream_region_allocate(stream.get(), TEST_DEFAULT_STREAM_SIZE + 1UL, &region) !=
 				  0);
 		});
 
@@ -96,7 +96,7 @@ int main(int argc, char *argv[])
 			auto region = initialize_stream_single_region(stream.get(), region_size, {});
 			verify(stream.get(), region, {}, {});
 
-			RC_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
+			UT_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
 		});
 
 		ret += rc::check("verify if a stream of various block_sizes can be created", [&]() {
@@ -108,7 +108,7 @@ int main(int argc, char *argv[])
 			auto region = initialize_stream_single_region(stream.get(), block_size / 10UL, {});
 			verify(stream.get(), region, {}, {});
 
-			RC_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
+			UT_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
 		});
 
 		/* verify if a stream of block_size = 0 cannot be created */

--- a/tests/unittest/id_manager.cpp
+++ b/tests/unittest/id_manager.cpp
@@ -23,7 +23,7 @@ void release_ids(id_manager *manager, size_t size, It &&it)
 {
 	for (size_t i = 0; i < size; i++) {
 		int ret = id_manager_release(manager, *it);
-		RC_ASSERT(ret == 0);
+		UT_ASSERT(ret == 0);
 		++it;
 	}
 }
@@ -81,7 +81,7 @@ int main()
 
 					/* Id will either be bigger than all existing (==
 					 * acquired_ids.size()) or will be a reused one. */
-					RC_ASSERT(id <= acquired_ids.size());
+					UT_ASSERT(id <= acquired_ids.size());
 
 					acquired_ids.emplace_back(id);
 				}
@@ -104,7 +104,7 @@ int main()
 			if (release_from_biggest) {
 				/* Since release was always done in reverse order, all ids should be
 				 * sorted. */
-				RC_ASSERT(std::is_sorted(acquired_ids.begin(), acquired_ids.end()));
+				UT_ASSERT(std::is_sorted(acquired_ids.begin(), acquired_ids.end()));
 			}
 		});
 
@@ -113,13 +113,13 @@ int main()
 			auto manager = make_id_manager();
 			for (unsigned i = 0; i < ids_to_acquire; i++) {
 				auto id = id_manager_acquire(manager.get());
-				RC_ASSERT(id == i);
+				UT_ASSERT(id == i);
 			}
 
 			auto to_release =
 				*rc::gen::unique<std::vector<unsigned>>(rc::gen::inRange<unsigned>(0, ids_to_acquire));
 			for (auto id : to_release) {
-				RC_ASSERT(id_manager_release(manager.get(), id) == 0);
+				UT_ASSERT(id_manager_release(manager.get(), id) == 0);
 			}
 
 			std::vector<unsigned> reacquired;
@@ -129,7 +129,7 @@ int main()
 			}
 
 			std::sort(to_release.begin(), to_release.end());
-			RC_ASSERT(std::equal(reacquired.begin(), reacquired.end(), to_release.begin()));
+			UT_ASSERT(std::equal(reacquired.begin(), reacquired.end(), to_release.begin()));
 		});
 	});
 }

--- a/tests/unittest/region_runtime_initialize.cpp
+++ b/tests/unittest/region_runtime_initialize.cpp
@@ -34,14 +34,14 @@ int main(int argc, char *argv[])
 
 				std::vector<pmemstream_region_runtime *> threads_data(concurrency);
 				parallel_exec(concurrency, [&](size_t tid) {
-					RC_ASSERT(pmemstream_region_runtime_initialize(stream.get(), region,
+					UT_ASSERT(pmemstream_region_runtime_initialize(stream.get(), region,
 										       &threads_data[tid]) == 0);
 
 					auto is_nullptr = threads_data[tid] == nullptr;
-					RC_ASSERT(!is_nullptr);
+					UT_ASSERT(!is_nullptr);
 				});
 
-				RC_ASSERT(all_equal(threads_data));
+				UT_ASSERT(all_equal(threads_data));
 			});
 
 		ret += rc::check("verify that pmemstream_region_runtime_initialize clears region after last entry",
@@ -85,7 +85,7 @@ int main(int argc, char *argv[])
 
 						 auto garbage_dst = garbage_destination(stream.get(), last_entry);
 						 for (size_t i = 0; i < garbage.size(); i++) {
-							 RC_ASSERT(garbage_dst[i] == 0);
+							 UT_ASSERT(garbage_dst[i] == 0);
 						 }
 					 }
 				 });

--- a/tests/unittest/reserve_publish.cpp
+++ b/tests/unittest/reserve_publish.cpp
@@ -48,10 +48,10 @@ int main(int argc, char *argv[])
 				const auto extra_entry = my_data.back();
 				int ret = pmemstream_append(stream.get(), region, nullptr, extra_entry.data(),
 							    extra_entry.size(), nullptr);
-				RC_ASSERT(ret == 0);
+				UT_ASSERT(ret == 0);
 				verify(stream.get(), region, data, my_data);
 
-				RC_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
+				UT_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
 			});
 
 		ret += rc::check("verify if reserve+publish by hand will behave the same as regular append",
@@ -66,7 +66,7 @@ int main(int argc, char *argv[])
 						 verify(stream.get(), region, data, {});
 						 a_data = get_elements_in_region(stream.get(), region);
 
-						 RC_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
+						 UT_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
 					 }
 					 /* publish-reserve by hand of the same 'data' (in a different file) */
 					 std::vector<std::string> rp_data;
@@ -78,10 +78,10 @@ int main(int argc, char *argv[])
 						 reserve_and_publish(stream.get(), region, data);
 						 rp_data = get_elements_in_region(stream.get(), region);
 
-						 RC_ASSERT(std::equal(a_data.begin(), a_data.end(), rp_data.begin(),
+						 UT_ASSERT(std::equal(a_data.begin(), a_data.end(), rp_data.begin(),
 								      rp_data.end()));
 
-						 RC_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
+						 UT_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
 					 }
 				 });
 
@@ -99,7 +99,7 @@ int main(int argc, char *argv[])
 						 int ret = pmemstream_reserve(stream.get(), region, nullptr,
 									      extra_entry.size(), &reserved_entry,
 									      &reserved_data);
-						 RC_ASSERT(ret == 0);
+						 UT_ASSERT(ret == 0);
 
 						 std::memcpy(reinterpret_cast<char *>(reserved_data),
 							     extra_entry.data(), extra_entry.size());

--- a/tests/unittest/util_popcount.cpp
+++ b/tests/unittest/util_popcount.cpp
@@ -33,7 +33,7 @@ int main()
 				const auto size = data.size() * sizeof(uint64_t);
 				const auto count =
 					util_popcount_memory(reinterpret_cast<const uint8_t *>(data.data()), size);
-				RC_ASSERT(count == expected);
+				UT_ASSERT(count == expected);
 			});
 
 		ret += rc::check("verify if popcount handles sizes which are not multiple of 8",
@@ -48,7 +48,7 @@ int main()
 					 const auto to_middle_count = util_popcount_memory(ptr, middle);
 					 const auto all_count = util_popcount_memory(ptr, size);
 
-					 RC_ASSERT(to_middle_count + (size - middle) == all_count);
+					 UT_ASSERT(to_middle_count + (size - middle) == all_count);
 				 });
 
 		ret += rc::check(
@@ -82,7 +82,7 @@ int main()
 				/* Calculate popcount for the second time and make sure the result differs
 				 * from the original one by exactly ones_diff. */
 				const auto second_count = static_cast<int>(util_popcount_memory(ptr, size));
-				RC_ASSERT(first_count + ones_diff == second_count);
+				UT_ASSERT(first_count + ones_diff == second_count);
 			});
 	});
 }


### PR DESCRIPTION
This makes it possible to use UT_ASSERT within rc::check (each exception
is treated as test failure).

Convert all RC_ASSERTs to UT_ASSERTs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemstream/103)
<!-- Reviewable:end -->
