### PR TITLE
Check if memory is zeroed before creating empty_span in region init

### DIFF
--- a/src/common/util.h
+++ b/src/common/util.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2021, Intel Corporation */
+/* Copyright 2021-2022, Intel Corporation */
 
 /* Common, internal utils */
 
@@ -8,6 +8,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <string.h>
 
 #define ALIGN_UP(size, align) (((size) + (align)-1) & ~((align)-1))
 #define ALIGN_DOWN(size, align) ((size) & ~((align)-1))
@@ -32,6 +33,19 @@ static inline size_t util_popcount_memory(const uint8_t *data, size_t size)
 	}
 
 	return count;
+}
+
+static inline int util_is_zeroed(const void *addr, size_t len)
+{
+	const char *a = (const char *)addr;
+
+	if (len == 0)
+		return 1;
+
+	if (a[0] == 0 && memcmp(a, a + 1, len - 1) == 0)
+		return 1;
+
+	return 0;
 }
 
 #endif /* LIBPMEMSTREAM_UTIL_H */

--- a/src/region.c
+++ b/src/region.c
@@ -248,6 +248,7 @@ static void region_runtime_clear_from_tail(struct pmemstream *stream, struct pme
 	size_t remaining_size = region_end_offset - tail;
 
 	if (remaining_size != 0) {
+		assert(remaining_size >= SPAN_EMPTY_METADATA_SIZE);
 		span_create_empty(stream, tail, remaining_size - SPAN_EMPTY_METADATA_SIZE);
 	}
 

--- a/src/span.c
+++ b/src/span.c
@@ -5,6 +5,7 @@
 
 #include <assert.h>
 
+#include "common/util.h"
 #include "libpmemstream_internal.h"
 
 const span_bytes *span_offset_to_span_ptr(const struct pmemstream *stream, uint64_t offset)
@@ -24,7 +25,9 @@ void span_create_empty(struct pmemstream *stream, uint64_t offset, size_t size)
 	span[0] = size | SPAN_EMPTY;
 
 	void *dest = ((uint8_t *)span) + SPAN_EMPTY_METADATA_SIZE;
-	stream->memset(dest, 0, size, PMEM2_F_MEM_NONTEMPORAL | PMEM2_F_MEM_NODRAIN);
+	if (!util_is_zeroed(dest, size)) {
+		stream->memset(dest, 0, size, PMEM2_F_MEM_NONTEMPORAL | PMEM2_F_MEM_NODRAIN);
+	}
 	stream->persist(span, SPAN_EMPTY_METADATA_SIZE);
 }
 


### PR DESCRIPTION
Situation when data is non-zero can only happen if there was a crash,
which should be unlikely situation. Because of that, it makes sense
to first check the data - read bandwith for Persistent Memory is
higher than write bandwidth.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemstream/104)
<!-- Reviewable:end -->
