### PR TITLE
Use temporal memcpy in append

### DIFF
--- a/src/libpmemstream.c
+++ b/src/libpmemstream.c
@@ -233,7 +233,7 @@ int pmemstream_append(struct pmemstream *stream, struct pmemstream_region region
 		return ret;
 	}
 
-	stream->memcpy(reserved_dest, data, size, PMEM2_F_MEM_NONTEMPORAL | PMEM2_F_MEM_NODRAIN);
+	stream->memcpy(reserved_dest, data, size, PMEM2_F_MEM_NODRAIN);
 	span_create_entry_no_flush_data(stream, reserved_entry.offset, size, util_popcount_memory(data, size));
 	region_runtime_increase_committed_offset(region_runtime, pmemstream_entry_total_size_aligned(size));
 


### PR DESCRIPTION
In current implementation using temporal memcpy instead of nontemporal
have better and more stable performance.

- [x] Make more measurements

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemstream/106)
<!-- Reviewable:end -->
