### PR TITLE
CI: rename 'gh-pages' branch to 'docs'

### DIFF
--- a/doc/RELEASE_STEPS.md
+++ b/doc/RELEASE_STEPS.md
@@ -33,6 +33,8 @@ Publish package and make it official:
 - announce the release on pmem group and on pmem slack channel(s)
 
 Later, for major/minor release:
-- once gh-pages branch contains new documentation:
+
+<!-- XXX: re-write this paragraph when transition to pmem.io is done -->
+- once 'docs' branch contains new documentation:
   - add there (in index.md) new links to manpages and Doxygen docs
   - update there "Releases' support status" table (update any other release's status if needed)

--- a/utils/docker/run-doc-update.sh
+++ b/utils/docker/run-doc-update.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2018-2021, Intel Corporation
+# Copyright 2018-2022, Intel Corporation
 
 #
 # run-doc-update.sh - is called inside a Docker container,
 #		to build docs for 'valid branches' and to create a pull request
-#		with and update of documentation files (on gh-pages).
+#		with and update of documentation files (on 'docs' branch).
 #
 
 set -e
@@ -25,7 +25,7 @@ export GITHUB_TOKEN=${DOC_UPDATE_GITHUB_TOKEN} # export for hub command
 REPO_DIR=$(mktemp -d -t pmemstream-XXX)
 ARTIFACTS_DIR=$(mktemp -d -t ARTIFACTS-XXX)
 
-# Only 'master' or 'stable-*' branches are valid; determine docs location dir on gh-pages branch
+# Only 'master' or 'stable-*' branches are valid; determine docs location dir on 'docs' branch
 TARGET_BRANCH=${CI_BRANCH}
 if [[ "${TARGET_BRANCH}" == "master" ]]; then
 	TARGET_DOCS_DIR="master"
@@ -67,9 +67,9 @@ cp -r ${REPO_DIR}/doc ${ARTIFACTS_DIR}/
 
 cd ${REPO_DIR}
 
-# Checkout gh-pages and copy docs
-GH_PAGES_NAME="${TARGET_DOCS_DIR}-gh-pages-update"
-git checkout -B ${GH_PAGES_NAME} upstream/gh-pages
+# Checkout 'docs' and copy generated documentation
+DOCS_BRANCH_NAME="${TARGET_DOCS_DIR}-docs-update"
+git checkout -B ${DOCS_BRANCH_NAME} upstream/docs
 git clean -dfx
 
 # Clean old content, since some files might have been deleted
@@ -84,12 +84,12 @@ echo "Add and push changes:"
 # In that case we want to force push anyway (there might be open pull request with
 # changes which were reverted).
 git add -A
-git commit -m "doc: automatic gh-pages docs update" && true
-git push -f ${ORIGIN} ${GH_PAGES_NAME}
+git commit -m "doc: automatic docs update for ${TARGET_BRANCH}" && true
+git push -f ${ORIGIN} ${DOCS_BRANCH_NAME}
 
 # Makes pull request.
 # When there is already an open PR or there are no changes an error is thrown, which we ignore.
-hub pull-request -f -b ${DOC_REPO_OWNER}:gh-pages -h ${BOT_NAME}:${GH_PAGES_NAME} \
-	-m "doc: automatic gh-pages docs update" && true
+hub pull-request -f -b ${DOC_REPO_OWNER}:docs -h ${BOT_NAME}:${DOCS_BRANCH_NAME} \
+	-m "doc: automatic docs update for ${TARGET_BRANCH}" && true
 
 popd


### PR DESCRIPTION
We've begun the process of moving the gh-pages content - generated docs -
into pmem/pmem.github.io repository. It's now required to remove gh-pages
branch here because its content conflicts with pmem.github.io's content.

- [x] before merging this change we have to actually update the name of the branch (gh-pages -> docs)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemstream/109)
<!-- Reviewable:end -->
