### PR TITLE
Initialize region_runtime_ptr to null in benchmarks

### DIFF
--- a/benchmarks/append/main.cpp
+++ b/benchmarks/append/main.cpp
@@ -253,7 +253,7 @@ class pmemstream_workload : public workload_base {
  private:
 	config cfg;
 	struct pmemstream_region region;
-	pmemstream_region_runtime *region_runtime_ptr;
+	pmemstream_region_runtime *region_runtime_ptr = nullptr;
 	std::unique_ptr<struct pmemstream, std::function<void(struct pmemstream *)>> stream;
 };
 


### PR DESCRIPTION
--null-region-runtime caused segfault because it was not initialized.