### PR TITLE
Do not use UT_FATAL in run_test

### DIFF
--- a/tests/common/unittest.hpp
+++ b/tests/common/unittest.hpp
@@ -69,9 +69,11 @@ static inline int run_test(std::function<void()> test)
 	try {
 		test();
 	} catch (std::exception &e) {
-		UT_FATALexc(e);
+		UT_EXCEPTION(e);
+		abort();
 	} catch (...) {
-		UT_FATAL("catch(...){}");
+		std::cerr << "catch(...){}" << std::endl;
+		abort();
 	}
 
 	return 0;


### PR DESCRIPTION
UT_FATAL (and family) throws exception on failure which
means that we have uncaught exceptions (reported by coverage).

Just print the error to stderr and abort manually.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemstream/113)
<!-- Reviewable:end -->
