### PR TITLE
Align region to block_size and first entry in region to 64B

### DIFF
--- a/src/libpmemstream_internal.h
+++ b/src/libpmemstream_internal.h
@@ -18,17 +18,15 @@ extern "C" {
 #define PMEMSTREAM_SIGNATURE ("PMEMSTREAM")
 #define PMEMSTREAM_SIGNATURE_SIZE (64)
 
-struct pmemstream_data {
-	struct pmemstream_header {
-		char signature[PMEMSTREAM_SIGNATURE_SIZE];
-		uint64_t stream_size;
-		uint64_t block_size;
-	} header;
-	span_bytes spans[];
+struct pmemstream_header {
+	char signature[PMEMSTREAM_SIGNATURE_SIZE];
+	uint64_t stream_size;
+	uint64_t block_size;
 };
 
 struct pmemstream {
-	struct pmemstream_data *data;
+	struct pmemstream_header *header;
+	span_bytes *spans;
 	size_t stream_size;
 	size_t usable_size;
 	size_t block_size;
@@ -44,7 +42,7 @@ struct pmemstream {
 
 static inline const uint8_t *pmemstream_offset_to_ptr(const struct pmemstream *stream, uint64_t offset)
 {
-	return (const uint8_t *)stream->data->spans + offset;
+	return (const uint8_t *)stream->spans + offset;
 }
 
 #ifdef __cplusplus

--- a/src/span.h
+++ b/src/span.h
@@ -54,7 +54,8 @@ struct span_runtime {
 };
 
 #define SPAN_EMPTY_METADATA_SIZE (MEMBER_SIZE(span_runtime, empty))
-#define SPAN_REGION_METADATA_SIZE (MEMBER_SIZE(span_runtime, region))
+/* XXX: use CACHELINE_SIZE + static_assert 64 <= MEMBER_SIZE(span_runtime, entry)*/
+#define SPAN_REGION_METADATA_SIZE 64
 #define SPAN_ENTRY_METADATA_SIZE (MEMBER_SIZE(span_runtime, entry))
 
 typedef uint64_t span_bytes;

--- a/tests/layout/iterate_validation.cpp
+++ b/tests/layout/iterate_validation.cpp
@@ -80,7 +80,7 @@ int main(int argc, char *argv[])
 
 					pmemstream_entry_iterator_delete(&eiter);
 					/* This pointer is not safe to read - it points to uninitialized data */
-					auto data_ptr = reinterpret_cast<char *>(stream->data->spans) + entry.offset;
+					auto data_ptr = reinterpret_cast<char *>(stream->spans) + entry.offset;
 
 					auto partial_span =
 						generate_inconsistent_span(entry_span ? SPAN_ENTRY : SPAN_EMPTY);


### PR DESCRIPTION
Until now, we only aligned size of the region to block_size.
This is not very useful if starting offset is not aligned
as well.

Also, align first entry in region to 64B to ease future
experiments/deelopment around entry alignment.