### PR TITLE
Change UT_ASSERT to UT_ASSERTeq where needed

### DIFF
--- a/tests/api_c/append_entry.c
+++ b/tests/api_c/append_entry.c
@@ -34,7 +34,7 @@ void test_entry_iterator(char *path)
 
 	entry_data = pmemstream_entry_data(stream, entry);
 	UT_ASSERTne(entry_data, NULL);
-	UT_ASSERT(entry_data->data == data.data);
+	UT_ASSERTeq(entry_data->data, data.data);
 
 	UT_ASSERTeq(pmemstream_entry_length(stream, entry), sizeof(data));
 

--- a/tests/common/stream_helpers.hpp
+++ b/tests/common/stream_helpers.hpp
@@ -15,7 +15,7 @@ void append(struct pmemstream *stream, struct pmemstream_region region,
 {
 	for (const auto &e : data) {
 		auto ret = pmemstream_append(stream, region, region_runtime, e.data(), e.size(), nullptr);
-		UT_ASSERT(ret == 0);
+		UT_ASSERTeq(ret, 0);
 	}
 }
 
@@ -27,7 +27,7 @@ void reserve_and_publish(struct pmemstream *stream, struct pmemstream_region reg
 	pmemstream_region_runtime *runtime = nullptr;
 	if (!is_runtime_initialized) {
 		int ret = pmemstream_region_runtime_initialize(stream, region, &runtime);
-		UT_ASSERT(ret == 0);
+		UT_ASSERTeq(ret, 0);
 	}
 
 	for (const auto &d : data) {
@@ -35,13 +35,13 @@ void reserve_and_publish(struct pmemstream *stream, struct pmemstream_region reg
 		struct pmemstream_entry reserved_entry;
 		void *reserved_data;
 		int ret = pmemstream_reserve(stream, region, nullptr, d.size(), &reserved_entry, &reserved_data);
-		UT_ASSERT(ret == 0);
+		UT_ASSERTeq(ret, 0);
 
 		/* write into the reserved space and publish (persist) it */
 		memcpy(reserved_data, d.data(), d.size());
 
 		ret = pmemstream_publish(stream, region, runtime, d.data(), d.size(), &reserved_entry);
-		UT_ASSERT(ret == 0);
+		UT_ASSERTeq(ret, 0);
 	}
 }
 
@@ -49,7 +49,7 @@ struct pmemstream_region initialize_stream_single_region(struct pmemstream *stre
 							 const std::vector<std::string> &data)
 {
 	struct pmemstream_region new_region;
-	UT_ASSERT(pmemstream_region_allocate(stream, region_size, &new_region) == 0);
+	UT_ASSERTeq(pmemstream_region_allocate(stream, region_size, &new_region), 0);
 	/* region_size is aligned up to block_size, on allocation, so it may be bigger than expected */
 	UT_ASSERT(pmemstream_region_size(stream, new_region) >= region_size);
 
@@ -75,7 +75,7 @@ struct pmemstream_region get_first_region(struct pmemstream *stream)
 struct pmemstream_entry get_last_entry(pmemstream *stream, pmemstream_region region)
 {
 	struct pmemstream_entry_iterator *eiter;
-	UT_ASSERT(pmemstream_entry_iterator_new(&eiter, stream, region) == 0);
+	UT_ASSERTeq(pmemstream_entry_iterator_new(&eiter, stream, region), 0);
 
 	struct pmemstream_entry last_entry = {0};
 	struct pmemstream_entry tmp_entry;
@@ -96,12 +96,12 @@ std::vector<std::string> get_elements_in_region(struct pmemstream *stream, struc
 	std::vector<std::string> result;
 
 	struct pmemstream_entry_iterator *eiter;
-	UT_ASSERT(pmemstream_entry_iterator_new(&eiter, stream, region) == 0);
+	UT_ASSERTeq(pmemstream_entry_iterator_new(&eiter, stream, region), 0);
 
 	struct pmemstream_entry entry;
 	struct pmemstream_region r;
 	while (pmemstream_entry_iterator_next(eiter, &r, &entry) == 0) {
-		UT_ASSERT(r.offset == region.offset);
+		UT_ASSERTeq(r.offset, region.offset);
 		auto data_ptr = reinterpret_cast<const char *>(pmemstream_entry_data(stream, entry));
 		result.emplace_back(data_ptr, pmemstream_entry_length(stream, entry));
 	}

--- a/tests/layout/iterate_validation.cpp
+++ b/tests/layout/iterate_validation.cpp
@@ -71,7 +71,7 @@ int main(int argc, char *argv[])
 					std::vector<std::string> result;
 
 					struct pmemstream_entry_iterator *eiter;
-					UT_ASSERT(pmemstream_entry_iterator_new(&eiter, stream.get(), region) == 0);
+					UT_ASSERTeq(pmemstream_entry_iterator_new(&eiter, stream.get(), region), 0);
 
 					struct pmemstream_entry entry;
 					while (pmemstream_entry_iterator_next(eiter, nullptr, &entry) == 0) {
@@ -93,7 +93,7 @@ int main(int argc, char *argv[])
 								      TEST_DEFAULT_STREAM_SIZE, false);
 					auto stream_data = get_elements_in_region(stream.get(), region);
 					UT_ASSERT(std::equal(data.begin(), data.end(), stream_data.begin()));
-					UT_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
+					UT_ASSERTeq(pmemstream_region_free(stream.get(), region), 0);
 				}
 			});
 	});

--- a/tests/unittest/append.cpp
+++ b/tests/unittest/append.cpp
@@ -35,7 +35,7 @@ int main(int argc, char *argv[])
 				verify(stream.get(), region, data, {});
 				append(stream.get(), region, NULL, extra_data);
 				verify(stream.get(), region, data, extra_data);
-				UT_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
+				UT_ASSERTeq(pmemstream_region_free(stream.get(), region), 0);
 			});
 
 		/* verify if an entry of size = 0 can be appended and entry with size > region's size cannot */
@@ -89,22 +89,22 @@ int main(int argc, char *argv[])
 			struct pmemstream_entry ne = {0}, prev_ne = {0};
 			while (elems-- > 0) {
 				auto ret = pmemstream_append(stream.get(), region, nullptr, e.data(), e.size(), &ne);
-				UT_ASSERT(ret == 0);
+				UT_ASSERTeq(ret, 0);
 				UT_ASSERT(ne.offset > prev_ne.offset);
 				prev_ne = ne;
 			}
 			/* next append should not fit */
 			auto ret = pmemstream_append(stream.get(), region, nullptr, e.data(), e.size(), &ne);
-			UT_ASSERT(ne.offset == prev_ne.offset);
+			UT_ASSERTeq(ne.offset, prev_ne.offset);
 			/* XXX: should be updated with the real error code, when available */
-			UT_ASSERT(ret == -1);
+			UT_ASSERTeq(ret, -1);
 			e.resize(4);
 			/* ... but smaller entry should fit just in */
 			ret = pmemstream_append(stream.get(), region, nullptr, e.data(), e.size(), &ne);
 			UT_ASSERT(ne.offset > prev_ne.offset);
-			UT_ASSERT(ret == 0);
+			UT_ASSERTeq(ret, 0);
 
-			UT_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
+			UT_ASSERTeq(pmemstream_region_free(stream.get(), region), 0);
 		});
 
 		ret += rc::check("verify if iteration return proper elements after pmemstream reopen",
@@ -121,7 +121,7 @@ int main(int argc, char *argv[])
 						 auto stream = make_pmemstream(path, TEST_DEFAULT_BLOCK_SIZE,
 									       TEST_DEFAULT_STREAM_SIZE, false);
 						 verify(stream.get(), region, data, {});
-						 UT_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
+						 UT_ASSERTeq(pmemstream_region_free(stream.get(), region), 0);
 					 }
 				 });
 
@@ -147,7 +147,7 @@ int main(int argc, char *argv[])
 
 						 append(stream.get(), region, runtime, extra_data);
 						 verify(stream.get(), region, data, extra_data);
-						 UT_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
+						 UT_ASSERTeq(pmemstream_region_free(stream.get(), region), 0);
 					 }
 				 });
 	});

--- a/tests/unittest/concurrent_iterate.cpp
+++ b/tests/unittest/concurrent_iterate.cpp
@@ -36,7 +36,7 @@ int main(int argc, char *argv[])
 				});
 
 				UT_ASSERT(all_of(threads_data, predicates::equal(data)));
-				UT_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
+				UT_ASSERTeq(pmemstream_region_free(stream.get(), region), 0);
 			});
 
 		ret += rc::check("verify if each concurrent iteration observes the same data after stream reopen",
@@ -59,7 +59,7 @@ int main(int argc, char *argv[])
 						 });
 
 						 UT_ASSERT(all_of(threads_data, predicates::equal(data)));
-						 UT_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
+						 UT_ASSERTeq(pmemstream_region_free(stream.get(), region), 0);
 					 }
 				 });
 	});

--- a/tests/unittest/concurrent_iterate_with_append.cpp
+++ b/tests/unittest/concurrent_iterate_with_append.cpp
@@ -23,7 +23,7 @@ void concurrent_iterate_verify(pmemstream *stream, pmemstream_region region, con
 	std::vector<std::string> result;
 
 	struct pmemstream_entry_iterator *eiter;
-	UT_ASSERT(pmemstream_entry_iterator_new(&eiter, stream, region) == 0);
+	UT_ASSERTeq(pmemstream_entry_iterator_new(&eiter, stream, region), 0);
 
 	struct pmemstream_entry entry;
 

--- a/tests/unittest/create.cpp
+++ b/tests/unittest/create.cpp
@@ -40,7 +40,7 @@ int main(int argc, char *argv[])
 			auto region = initialize_stream_single_region(stream.get(), region_size, data);
 			verify(stream.get(), region, data, {});
 
-			UT_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
+			UT_ASSERTeq(pmemstream_region_free(stream.get(), region), 0);
 		});
 
 		ret += rc::check(
@@ -53,18 +53,18 @@ int main(int argc, char *argv[])
 
 				struct pmemstream_region_iterator *riter;
 				auto ret = pmemstream_region_iterator_new(&riter, stream.get());
-				UT_ASSERT(ret == 0);
+				UT_ASSERTeq(ret, 0);
 
 				struct pmemstream_region r;
 				ret = pmemstream_region_iterator_next(riter, &r);
-				UT_ASSERT(ret == 0);
-				UT_ASSERT(region.offset == r.offset);
+				UT_ASSERTeq(ret, 0);
+				UT_ASSERTeq(region.offset, r.offset);
 				/* there should be no more regions */
 				ret = pmemstream_region_iterator_next(riter, &r);
-				UT_ASSERT(ret == -1);
+				UT_ASSERTeq(ret, -1);
 
 				pmemstream_region_iterator_delete(&riter);
-				UT_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
+				UT_ASSERTeq(pmemstream_region_free(stream.get(), region), 0);
 			});
 
 		/* "verify if region of unexpected arbitrary sizes cannot be created" */
@@ -91,7 +91,7 @@ int main(int argc, char *argv[])
 			auto region = initialize_stream_single_region(stream.get(), region_size, {});
 			verify(stream.get(), region, {}, {});
 
-			UT_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
+			UT_ASSERTeq(pmemstream_region_free(stream.get(), region), 0);
 		});
 
 		ret += rc::check("verify if a stream of various block_sizes can be created", [&]() {
@@ -104,7 +104,7 @@ int main(int argc, char *argv[])
 			auto region = initialize_stream_single_region(stream.get(), block_size / 10UL, {});
 			verify(stream.get(), region, {}, {});
 
-			UT_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
+			UT_ASSERTeq(pmemstream_region_free(stream.get(), region), 0);
 		});
 
 		/* verify if a stream of block_size = 0 cannot be created */

--- a/tests/unittest/id_manager.cpp
+++ b/tests/unittest/id_manager.cpp
@@ -23,7 +23,7 @@ void release_ids(id_manager *manager, size_t size, It &&it)
 {
 	for (size_t i = 0; i < size; i++) {
 		int ret = id_manager_release(manager, *it);
-		UT_ASSERT(ret == 0);
+		UT_ASSERTeq(ret, 0);
 		++it;
 	}
 }
@@ -41,7 +41,7 @@ int main()
 
 			for (size_t i = 0; i < max_num_id_requests; i++) {
 				auto id = id_manager_acquire(manager.get());
-				UT_ASSERT(id == i);
+				UT_ASSERTeq(id, i);
 			}
 		}
 
@@ -51,10 +51,10 @@ int main()
 
 			for (size_t i = 0; i < max_num_id_requests; i++) {
 				auto id = id_manager_acquire(manager.get());
-				UT_ASSERT(id == 0);
+				UT_ASSERTeq(id, 0);
 
 				int ret = id_manager_release(manager.get(), id);
-				UT_ASSERT(ret == 0);
+				UT_ASSERTeq(ret, 0);
 			}
 		}
 
@@ -113,13 +113,13 @@ int main()
 			auto manager = make_id_manager();
 			for (unsigned i = 0; i < ids_to_acquire; i++) {
 				auto id = id_manager_acquire(manager.get());
-				UT_ASSERT(id == i);
+				UT_ASSERTeq(id, i);
 			}
 
 			auto to_release =
 				*rc::gen::unique<std::vector<unsigned>>(rc::gen::inRange<unsigned>(0, ids_to_acquire));
 			for (auto id : to_release) {
-				UT_ASSERT(id_manager_release(manager.get(), id) == 0);
+				UT_ASSERTeq(id_manager_release(manager.get(), id), 0);
 			}
 
 			std::vector<unsigned> reacquired;

--- a/tests/unittest/id_manager_multithreaded.cpp
+++ b/tests/unittest/id_manager_multithreaded.cpp
@@ -36,7 +36,7 @@ int main(int argc, char *argv[])
 
 			for (auto id : thread_ids[thread_id]) {
 				int ret = id_manager_release(manager.get(), id);
-				UT_ASSERT(ret == 0);
+				UT_ASSERTeq(ret, 0);
 			}
 		});
 

--- a/tests/unittest/region_runtime_initialize.cpp
+++ b/tests/unittest/region_runtime_initialize.cpp
@@ -85,7 +85,7 @@ int main(int argc, char *argv[])
 
 						 auto garbage_dst = garbage_destination(stream.get(), last_entry);
 						 for (size_t i = 0; i < garbage.size(); i++) {
-							 UT_ASSERT(garbage_dst[i] == 0);
+							 UT_ASSERTeq(garbage_dst[i], 0);
 						 }
 					 }
 				 });

--- a/tests/unittest/reserve_publish.cpp
+++ b/tests/unittest/reserve_publish.cpp
@@ -48,10 +48,10 @@ int main(int argc, char *argv[])
 				const auto extra_entry = my_data.back();
 				int ret = pmemstream_append(stream.get(), region, nullptr, extra_entry.data(),
 							    extra_entry.size(), nullptr);
-				UT_ASSERT(ret == 0);
+				UT_ASSERTeq(ret, 0);
 				verify(stream.get(), region, data, my_data);
 
-				UT_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
+				UT_ASSERTeq(pmemstream_region_free(stream.get(), region), 0);
 			});
 
 		ret += rc::check(
@@ -67,7 +67,7 @@ int main(int argc, char *argv[])
 					verify(stream.get(), region, data, {});
 					a_data = get_elements_in_region(stream.get(), region);
 
-					UT_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
+					UT_ASSERTeq(pmemstream_region_free(stream.get(), region), 0);
 				}
 				/* publish-reserve by hand of the same 'data' (in a different file) */
 				std::vector<std::string> rp_data;
@@ -82,7 +82,7 @@ int main(int argc, char *argv[])
 					UT_ASSERT(std::equal(a_data.begin(), a_data.end(), rp_data.begin(),
 							     rp_data.end()));
 
-					UT_ASSERT(pmemstream_region_free(stream.get(), region) == 0);
+					UT_ASSERTeq(pmemstream_region_free(stream.get(), region), 0);
 				}
 			});
 
@@ -100,7 +100,7 @@ int main(int argc, char *argv[])
 						 int ret = pmemstream_reserve(stream.get(), region, nullptr,
 									      extra_entry.size(), &reserved_entry,
 									      &reserved_data);
-						 UT_ASSERT(ret == 0);
+						 UT_ASSERTeq(ret, 0);
 
 						 std::memcpy(reinterpret_cast<char *>(reserved_data),
 							     extra_entry.data(), extra_entry.size());

--- a/tests/unittest/util_popcount.cpp
+++ b/tests/unittest/util_popcount.cpp
@@ -33,7 +33,7 @@ int main()
 				const auto size = data.size() * sizeof(uint64_t);
 				const auto count =
 					util_popcount_memory(reinterpret_cast<const uint8_t *>(data.data()), size);
-				UT_ASSERT(count == expected);
+				UT_ASSERTeq(count, expected);
 			});
 
 		ret += rc::check("verify if popcount handles sizes which are not multiple of 8",
@@ -48,7 +48,7 @@ int main()
 					 const auto to_middle_count = util_popcount_memory(ptr, middle);
 					 const auto all_count = util_popcount_memory(ptr, size);
 
-					 UT_ASSERT(to_middle_count + (size - middle) == all_count);
+					 UT_ASSERTeq(to_middle_count + (size - middle), all_count);
 				 });
 
 		ret += rc::check(
@@ -82,7 +82,7 @@ int main()
 				/* Calculate popcount for the second time and make sure the result differs
 				 * from the original one by exactly ones_diff. */
 				const auto second_count = static_cast<int>(util_popcount_memory(ptr, size));
-				UT_ASSERT(first_count + ones_diff == second_count);
+				UT_ASSERTeq(first_count + ones_diff, second_count);
 			});
 	});
 }


### PR DESCRIPTION
Change was done with little bit of regex engineering.
```
find -iname "*.cpp" | xargs sed -ri 's/UT_ASSERT\((.+)==(.+)\)/UT_ASSERTeq(\1,\2)/g'
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemstream/119)
<!-- Reviewable:end -->
