### PR TITLE
Check if stream is not NULL and offset is not above stream_size

### DIFF
--- a/src/libpmemstream_internal.h
+++ b/src/libpmemstream_internal.h
@@ -42,7 +42,12 @@ struct pmemstream {
 
 static inline const uint8_t *pmemstream_offset_to_ptr(const struct pmemstream *stream, uint64_t offset)
 {
-	return (const uint8_t *)stream->spans + offset;
+	if (stream) {
+		if (stream->header->stream_size >= offset) {
+			return (const uint8_t *)stream->spans + offset;
+		}
+	}
+	return NULL;
 }
 
 #ifdef __cplusplus

--- a/src/region.c
+++ b/src/region.c
@@ -238,8 +238,11 @@ static void region_runtime_clear_from_tail(struct pmemstream *stream, struct pme
 	assert(region_runtime_get_state_acquire(region_runtime) == REGION_RUNTIME_STATE_DIRTY);
 
 	uint64_t append_offset = region_runtime_get_append_offset_acquire(region_runtime);
-	struct span_runtime region_rt = span_get_region_runtime(stream, region.offset);
-	size_t region_end_offset = region.offset + region_rt.total_size;
+	struct span_runtime *region_rt;
+	if (span_get_region_runtime(stream, region.offset, &region_rt) == -1) {
+		return;
+	}
+	size_t region_end_offset = region.offset + region_rt->total_size;
 	size_t remaining_size = region_end_offset - append_offset;
 
 	if (remaining_size != 0) {

--- a/src/span.h
+++ b/src/span.h
@@ -74,17 +74,16 @@ void span_create_entry(struct pmemstream *stream, uint64_t offset, size_t data_s
 void span_create_entry_no_flush_data(struct pmemstream *stream, uint64_t offset, size_t data_size, size_t popcount);
 void span_create_region(struct pmemstream *stream, uint64_t offset, size_t size);
 
-uint64_t span_get_size(const span_bytes *span);
-enum span_type span_get_type(const span_bytes *span);
+uint64_t span_get_size(const span_bytes **span);
+enum span_type span_get_type(const span_bytes **span);
 
 /* Obtain span_runtime structure describing span at 'offset'. offset must be 8-bytes aligned. */
-struct span_runtime span_get_runtime(const struct pmemstream *stream, uint64_t offset);
+int span_get_runtime(const struct pmemstream *stream, uint64_t offset, struct span_runtime **runtime);
 
-/* Works similar to the function above but span must be of certain type. Does not verify if span type at 'offset'
- * is correct. */
-struct span_runtime span_get_empty_runtime(const struct pmemstream *stream, uint64_t offset);
-struct span_runtime span_get_entry_runtime(const struct pmemstream *stream, uint64_t offset);
-struct span_runtime span_get_region_runtime(const struct pmemstream *stream, uint64_t offset);
+/* Works similar to the function above but span must be of certain type. */
+int span_get_empty_runtime(const struct pmemstream *stream, uint64_t offset, struct span_runtime **runtime);
+int span_get_entry_runtime(const struct pmemstream *stream, uint64_t offset, struct span_runtime **runtime);
+int span_get_region_runtime(const struct pmemstream *stream, uint64_t offset, struct span_runtime **runtime);
 
 #ifdef __cplusplus
 } /* end extern "C" */

--- a/tests/api_c/append_entry.c
+++ b/tests/api_c/append_entry.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 /* Copyright 2021-2022, Intel Corporation */
 
+#include "span.h"
 #include "unittest.h"
 
 /**
@@ -12,7 +13,7 @@ struct entry_data {
 	uint64_t data;
 };
 
-void test_entry_iterator(char *path)
+void valid_input_test(char *path)
 {
 	int ret;
 	struct entry_data data;
@@ -43,6 +44,96 @@ void test_entry_iterator(char *path)
 	pmem2_map_delete(&map);
 }
 
+void invalid_region_test(char *path)
+{
+	int ret;
+	struct entry_data data;
+	data.data = UINT64_MAX;
+	struct pmemstream_entry *entry = NULL;
+
+	struct pmem2_map *map = map_open(path, TEST_DEFAULT_STREAM_SIZE, true);
+	struct pmemstream *stream;
+	ret = pmemstream_from_map(&stream, TEST_DEFAULT_BLOCK_SIZE, map);
+	UT_ASSERTeq(ret, 0);
+
+	struct pmemstream_region region = {.offset = ALIGN_DOWN(UINT64_MAX, sizeof(span_bytes))};
+
+	ret = pmemstream_append(stream, region, NULL, &data, sizeof(data), entry);
+	UT_ASSERTeq(ret, -1);
+	UT_ASSERTeq(entry, NULL);
+
+	pmemstream_delete(&stream);
+	pmem2_map_delete(&map);
+}
+
+void null_data_test(char *path)
+{
+	int ret;
+	struct pmemstream_entry *entry = NULL;
+
+	struct pmem2_map *map = map_open(path, TEST_DEFAULT_STREAM_SIZE, true);
+	struct pmemstream *stream;
+	ret = pmemstream_from_map(&stream, TEST_DEFAULT_BLOCK_SIZE, map);
+	UT_ASSERTeq(ret, 0);
+
+	struct pmemstream_region region;
+	ret = pmemstream_region_allocate(stream, TEST_DEFAULT_REGION_SIZE, &region);
+	UT_ASSERTeq(ret, 0);
+
+	ret = pmemstream_append(stream, region, NULL, NULL, 0, entry);
+	UT_ASSERTeq(ret, 0);
+	UT_ASSERTeq(entry, NULL);
+
+	pmemstream_region_free(stream, region);
+	pmemstream_delete(&stream);
+	pmem2_map_delete(&map);
+}
+
+void null_entry_test(char *path)
+{
+	int ret;
+	struct entry_data data;
+	data.data = PTRDIFF_MAX;
+	struct pmemstream_entry *entry = NULL;
+
+	struct pmem2_map *map = map_open(path, TEST_DEFAULT_STREAM_SIZE, true);
+	struct pmemstream *stream;
+	ret = pmemstream_from_map(&stream, TEST_DEFAULT_BLOCK_SIZE, map);
+	UT_ASSERTeq(ret, 0);
+
+	struct pmemstream_region region;
+	ret = pmemstream_region_allocate(stream, TEST_DEFAULT_REGION_SIZE, &region);
+	UT_ASSERTeq(ret, 0);
+
+	ret = pmemstream_append(stream, region, NULL, &data, sizeof(data), entry);
+	UT_ASSERTeq(ret, 0);
+	UT_ASSERTeq(entry, NULL);
+
+	pmemstream_region_free(stream, region);
+	pmemstream_delete(&stream);
+	pmem2_map_delete(&map);
+}
+
+void invalid_entry_test(char *path)
+{
+	int ret;
+	const struct entry_data *entry_data;
+	struct pmemstream_entry entry = {.offset = ALIGN_DOWN(UINT64_MAX, sizeof(span_bytes))};
+
+	struct pmem2_map *map = map_open(path, TEST_DEFAULT_STREAM_SIZE, true);
+	struct pmemstream *stream;
+	ret = pmemstream_from_map(&stream, TEST_DEFAULT_BLOCK_SIZE, map);
+	UT_ASSERTeq(ret, 0);
+
+	entry_data = pmemstream_entry_data(stream, entry);
+	UT_ASSERTeq(entry_data, NULL);
+
+	UT_ASSERTeq(pmemstream_entry_length(stream, entry), 0);
+
+	pmemstream_delete(&stream);
+	pmem2_map_delete(&map);
+}
+
 int main(int argc, char *argv[])
 {
 	if (argc < 2) {
@@ -53,7 +144,12 @@ int main(int argc, char *argv[])
 
 	char *path = argv[1];
 
-	test_entry_iterator(path);
+	valid_input_test(path);
+	// https://github.com/pmem/pmemstream/issues/121
+	// invalid_region_test(path);
+	null_data_test(path);
+	null_entry_test(path);
+	invalid_entry_test(path);
 
 	return 0;
 }

--- a/tests/api_c/entry_iterator.c
+++ b/tests/api_c/entry_iterator.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 /* Copyright 2021-2022, Intel Corporation */
 
+#include "span.h"
 #include "unittest.h"
 
 /**
@@ -8,7 +9,7 @@
  *					pmemstream_entry_iterator_next, pmemstream_entry_iterator_delete
  */
 
-void test_entry_iterator(char *path)
+void valid_input_test(char *path)
 {
 	int ret;
 	struct pmemstream_entry entry;
@@ -37,6 +38,112 @@ void test_entry_iterator(char *path)
 	pmem2_map_delete(&map);
 }
 
+void invalid_region_test(char *path)
+{
+	int ret;
+	struct pmem2_map *map = map_open(path, TEST_DEFAULT_STREAM_SIZE, true);
+	struct pmemstream *stream;
+	pmemstream_from_map(&stream, TEST_DEFAULT_BLOCK_SIZE, map);
+	struct pmemstream_entry_iterator *eiter;
+	struct pmemstream_entry entry;
+	struct pmemstream_region region;
+	struct pmemstream_region invalid_region = {.offset = ALIGN_DOWN(UINT64_MAX, sizeof(span_bytes))};
+	ret = pmemstream_region_allocate(stream, TEST_DEFAULT_REGION_SIZE, &region);
+	UT_ASSERTeq(ret, 0);
+
+	ret = pmemstream_entry_iterator_new(&eiter, stream, invalid_region);
+	UT_ASSERTeq(ret, -1);
+	UT_ASSERTeq(eiter, NULL);
+
+	ret = pmemstream_entry_iterator_new(&eiter, stream, region);
+	UT_ASSERTeq(ret, 0);
+	ret = pmemstream_entry_iterator_next(eiter, &invalid_region, &entry);
+	UT_ASSERTeq(ret, -1);
+
+	pmemstream_entry_iterator_delete(&eiter);
+	pmemstream_region_free(stream, region);
+	pmemstream_delete(&stream);
+	pmem2_map_delete(&map);
+}
+
+void null_stream_test(char *path)
+{
+	int ret;
+	struct pmem2_map *map = map_open(path, TEST_DEFAULT_STREAM_SIZE, true);
+	struct pmemstream *stream;
+	pmemstream_from_map(&stream, TEST_DEFAULT_BLOCK_SIZE, map);
+	struct pmemstream_entry_iterator *eiter;
+	struct pmemstream_region region;
+	ret = pmemstream_region_allocate(stream, TEST_DEFAULT_REGION_SIZE, &region);
+	UT_ASSERTeq(ret, 0);
+
+	ret = pmemstream_entry_iterator_new(&eiter, NULL, region);
+	UT_ASSERTeq(ret, -1);
+	UT_ASSERTeq(eiter, NULL);
+
+	pmemstream_region_free(stream, region);
+	pmemstream_delete(&stream);
+	pmem2_map_delete(&map);
+}
+
+void null_stream_and_invalid_region_test(char *path)
+{
+	struct pmemstream_entry_iterator *eiter;
+	struct pmemstream_region invalid_region = {.offset = ALIGN_DOWN(UINT64_MAX, sizeof(span_bytes))};
+	struct pmemstream *null_stream = NULL;
+	int ret;
+
+	ret = pmemstream_entry_iterator_new(&eiter, null_stream, invalid_region);
+	UT_ASSERTeq(ret, -1);
+	UT_ASSERTeq(eiter, NULL);
+}
+
+void null_entry_iterator_test(char *path)
+{
+	int ret;
+	struct pmem2_map *map = map_open(path, TEST_DEFAULT_STREAM_SIZE, true);
+	struct pmemstream *stream;
+	pmemstream_from_map(&stream, TEST_DEFAULT_BLOCK_SIZE, map);
+	struct pmemstream_entry_iterator *eiter = NULL;
+	struct pmemstream_region region;
+	ret = pmemstream_region_allocate(stream, TEST_DEFAULT_REGION_SIZE, &region);
+	UT_ASSERTeq(ret, 0);
+
+	ret = pmemstream_entry_iterator_new(&eiter, stream, region);
+	UT_ASSERTeq(ret, 0);
+	UT_ASSERTne(eiter, NULL);
+
+	pmemstream_entry_iterator_delete(&eiter);
+	pmemstream_region_free(stream, region);
+	pmemstream_delete(&stream);
+	pmem2_map_delete(&map);
+}
+
+void null_entry_test(char *path)
+{
+	int ret;
+	struct pmem2_map *map = map_open(path, TEST_DEFAULT_STREAM_SIZE, true);
+	struct pmemstream *stream;
+	pmemstream_from_map(&stream, TEST_DEFAULT_BLOCK_SIZE, map);
+	struct pmemstream_entry_iterator *eiter;
+	struct pmemstream_entry *entry = NULL;
+	struct pmemstream_region region;
+	ret = pmemstream_region_allocate(stream, TEST_DEFAULT_REGION_SIZE, &region);
+	UT_ASSERTeq(ret, 0);
+
+	ret = pmemstream_entry_iterator_new(&eiter, stream, region);
+	UT_ASSERTeq(ret, 0);
+
+	ret = pmemstream_entry_iterator_next(eiter, &region, entry);
+	UT_ASSERTeq(ret, -1);
+	UT_ASSERTeq(entry, NULL);
+
+	pmemstream_entry_iterator_delete(&eiter);
+	pmemstream_region_free(stream, region);
+	pmemstream_delete(&stream);
+	pmem2_map_delete(&map);
+}
+
 int main(int argc, char *argv[])
 {
 	if (argc < 2) {
@@ -47,7 +154,12 @@ int main(int argc, char *argv[])
 
 	char *path = argv[1];
 
-	test_entry_iterator(path);
+	valid_input_test(path);
+	invalid_region_test(path);
+	null_stream_test(path);
+	null_stream_and_invalid_region_test(path);
+	null_entry_iterator_test(path);
+	null_entry_test(path);
 
 	return 0;
 }

--- a/tests/api_c/region_iterator.c
+++ b/tests/api_c/region_iterator.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 /* Copyright 2021-2022, Intel Corporation */
 
+#include "span.h"
 #include "unittest.h"
 
 /**
@@ -8,7 +9,7 @@
  *					pmemstrem_region_iterator_next, pmemstream_region_iterator_delete
  */
 
-void test_region_iterator(char *path)
+void valid_input_test(char *path)
 {
 	int ret;
 	struct pmemstream_region_iterator *riter;
@@ -39,6 +40,40 @@ void test_region_iterator(char *path)
 	pmem2_map_delete(&map);
 }
 
+void invalid_region_test(char *path)
+{
+	struct pmem2_map *map = map_open(path, TEST_DEFAULT_STREAM_SIZE, true);
+	struct pmemstream *stream;
+	pmemstream_from_map(&stream, TEST_DEFAULT_BLOCK_SIZE, map);
+	struct pmemstream_region_iterator *riter;
+	struct pmemstream_region invalid_region = {.offset = ALIGN_DOWN(UINT64_MAX, sizeof(span_bytes))};
+	int ret;
+
+	ret = pmemstream_region_iterator_new(&riter, stream);
+	UT_ASSERTeq(ret, 0);
+	UT_ASSERTne(riter, NULL);
+
+	ret = pmemstream_region_iterator_next(riter, &invalid_region);
+	UT_ASSERTeq(ret, -1);
+
+	pmemstream_region_iterator_delete(&riter);
+	pmemstream_delete(&stream);
+	pmem2_map_delete(&map);
+}
+
+void null_stream_test()
+{
+	struct pmemstream_region_iterator *riter = NULL;
+	struct pmemstream *null_stream = NULL;
+	int ret;
+
+	ret = pmemstream_region_iterator_new(&riter, null_stream);
+	UT_ASSERTeq(ret, 0);
+	UT_ASSERTne(riter, NULL);
+
+	pmemstream_region_iterator_delete(&riter);
+}
+
 int main(int argc, char *argv[])
 {
 	if (argc < 2) {
@@ -49,7 +84,9 @@ int main(int argc, char *argv[])
 
 	char *path = argv[1];
 
-	test_region_iterator(path);
+	valid_input_test(path);
+	invalid_region_test(path);
+	null_stream_test();
 
 	return 0;
 }

--- a/tests/api_c/reserve_and_publish.c
+++ b/tests/api_c/reserve_and_publish.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 /* Copyright 2021-2022, Intel Corporation */
 
+#include "span.h"
 #include "unittest.h"
 #include <string.h>
 
@@ -12,7 +13,7 @@ struct entry_data {
 	uint64_t data;
 };
 
-void test_reserve_and_publish(char *path)
+void valid_input_test(char *path)
 {
 	int ret;
 	void *data_address = NULL;
@@ -39,7 +40,7 @@ void test_reserve_and_publish(char *path)
 	pmem2_map_delete(&map);
 }
 
-void test_reserve_and_publish_with_memcpy(char *path)
+void valid_input_test_with_memcpy(char *path)
 {
 	int ret;
 	void *data_address = NULL;
@@ -68,6 +69,108 @@ void test_reserve_and_publish_with_memcpy(char *path)
 	pmem2_map_delete(&map);
 }
 
+void invalid_region_test(char *path)
+{
+	int ret;
+	void *data_address = NULL;
+	struct entry_data data;
+	struct pmemstream_entry entry;
+	struct pmem2_map *map = map_open(path, TEST_DEFAULT_STREAM_SIZE, true);
+	struct pmemstream *stream;
+	ret = pmemstream_from_map(&stream, TEST_DEFAULT_BLOCK_SIZE, map);
+	UT_ASSERTeq(ret, 0);
+
+	struct pmemstream_region region = {.offset = ALIGN_DOWN(UINT64_MAX, sizeof(span_bytes))};
+
+	ret = pmemstream_reserve(stream, region, NULL, sizeof(data), &entry, &data_address);
+	UT_ASSERTeq(ret, -1);
+	UT_ASSERTeq(data_address, NULL);
+
+	ret = pmemstream_publish(stream, region, NULL, &data, sizeof(data), &entry);
+	UT_ASSERTeq(ret, -1);
+
+	pmemstream_region_free(stream, region);
+	pmemstream_delete(&stream);
+	pmem2_map_delete(&map);
+}
+
+void null_data_test(char *path)
+{
+	int ret;
+	void *data_address = NULL;
+	struct entry_data *data = NULL;
+	struct pmemstream_entry entry;
+	struct pmem2_map *map = map_open(path, TEST_DEFAULT_STREAM_SIZE, true);
+	struct pmemstream *stream;
+	ret = pmemstream_from_map(&stream, TEST_DEFAULT_BLOCK_SIZE, map);
+	UT_ASSERTeq(ret, 0);
+
+	struct pmemstream_region region;
+	ret = pmemstream_region_allocate(stream, TEST_DEFAULT_REGION_SIZE, &region);
+	UT_ASSERTeq(ret, 0);
+
+	ret = pmemstream_reserve(stream, region, NULL, 0, &entry, &data_address);
+	UT_ASSERTeq(ret, 0);
+	UT_ASSERTne(data_address, NULL);
+
+	ret = pmemstream_publish(stream, region, NULL, data, 0, &entry);
+	UT_ASSERTeq(ret, 0);
+
+	pmemstream_region_free(stream, region);
+	pmemstream_delete(&stream);
+	pmem2_map_delete(&map);
+}
+
+void zero_size_test(char *path)
+{
+	int ret;
+	void *data_address = NULL;
+	struct pmemstream_entry entry;
+	struct pmem2_map *map = map_open(path, TEST_DEFAULT_STREAM_SIZE, true);
+	struct pmemstream *stream;
+	ret = pmemstream_from_map(&stream, TEST_DEFAULT_BLOCK_SIZE, map);
+	UT_ASSERTeq(ret, 0);
+
+	struct pmemstream_region region;
+	ret = pmemstream_region_allocate(stream, TEST_DEFAULT_REGION_SIZE, &region);
+	UT_ASSERTeq(ret, 0);
+
+	ret = pmemstream_reserve(stream, region, NULL, 0, &entry, &data_address);
+	UT_ASSERTeq(ret, 0);
+	UT_ASSERTne(data_address, NULL);
+
+	pmemstream_region_free(stream, region);
+	pmemstream_delete(&stream);
+	pmem2_map_delete(&map);
+}
+
+void null_entry_test(char *path)
+{
+	int ret;
+	void *data_address = NULL;
+	struct entry_data data;
+	struct pmemstream_entry *entry = NULL;
+	struct pmem2_map *map = map_open(path, TEST_DEFAULT_STREAM_SIZE, true);
+	struct pmemstream *stream;
+	ret = pmemstream_from_map(&stream, TEST_DEFAULT_BLOCK_SIZE, map);
+	UT_ASSERTeq(ret, 0);
+
+	struct pmemstream_region region;
+	ret = pmemstream_region_allocate(stream, TEST_DEFAULT_REGION_SIZE, &region);
+	UT_ASSERTeq(ret, 0);
+
+	ret = pmemstream_reserve(stream, region, NULL, sizeof(data), entry, &data_address);
+	UT_ASSERTeq(ret, 0);
+	UT_ASSERTne(data_address, NULL);
+
+	ret = pmemstream_publish(stream, region, NULL, &data, sizeof(data), entry);
+	UT_ASSERTeq(ret, 0);
+
+	pmemstream_region_free(stream, region);
+	pmemstream_delete(&stream);
+	pmem2_map_delete(&map);
+}
+
 int main(int argc, char *argv[])
 {
 	if (argc < 2) {
@@ -78,8 +181,14 @@ int main(int argc, char *argv[])
 
 	char *path = argv[1];
 
-	test_reserve_and_publish(path);
-	test_reserve_and_publish_with_memcpy(path);
+	valid_input_test(path);
+	valid_input_test_with_memcpy(path);
+	// https://github.com/pmem/pmemstream/issues/121
+	// invalid_region_test(path);
+	null_data_test(path);
+	zero_size_test(path);
+	// https://github.com/pmem/pmemstream/issues/101
+	// null_entry_test(path);
 
 	return 0;
 }


### PR DESCRIPTION
in pmemstream_offset_to_ptr

Fixes segmentation fault in pmemstream_offset_to_ptr
and assertion fault in span_get_entry_runtime and span_get_region_runtime

Fixes: #98 #99 #100

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemstream/122)
<!-- Reviewable:end -->
