### PR TITLE
Extract span ptr and mempos from pmemstream to separate struct

### DIFF
--- a/src/libpmemstream_internal.h
+++ b/src/libpmemstream_internal.h
@@ -24,25 +24,33 @@ struct pmemstream_header {
 	uint64_t block_size;
 };
 
-struct pmemstream {
-	struct pmemstream_header *header;
+struct pmemstream_data_runtime {
 	span_bytes *spans;
-	size_t stream_size;
-	size_t usable_size;
-	size_t block_size;
 
 	pmem2_memcpy_fn memcpy;
 	pmem2_memset_fn memset;
 	pmem2_flush_fn flush;
 	pmem2_drain_fn drain;
 	pmem2_persist_fn persist;
+};
+
+struct pmemstream {
+	/* Points to pmem-resided header. */
+	struct pmemstream_header *header;
+
+	/* Describes data location and memory operations. */
+	struct pmemstream_data_runtime data;
+
+	size_t stream_size;
+	size_t usable_size;
+	size_t block_size;
 
 	struct region_runtimes_map *region_runtimes_map;
 };
 
-static inline const uint8_t *pmemstream_offset_to_ptr(const struct pmemstream *stream, uint64_t offset)
+static inline const uint8_t *pmemstream_offset_to_ptr(const struct pmemstream_data_runtime *data, uint64_t offset)
 {
-	return (const uint8_t *)stream->spans + offset;
+	return (const uint8_t *)data->spans + offset;
 }
 
 #ifdef __cplusplus

--- a/src/region.c
+++ b/src/region.c
@@ -238,12 +238,12 @@ static void region_runtime_clear_from_tail(struct pmemstream *stream, struct pme
 	assert(region_runtime_get_state_acquire(region_runtime) == REGION_RUNTIME_STATE_DIRTY);
 
 	uint64_t append_offset = region_runtime_get_append_offset_acquire(region_runtime);
-	struct span_runtime region_rt = span_get_region_runtime(stream, region.offset);
+	struct span_runtime region_rt = span_get_region_runtime(&stream->data, region.offset);
 	size_t region_end_offset = region.offset + region_rt.total_size;
 	size_t remaining_size = region_end_offset - append_offset;
 
 	if (remaining_size != 0) {
-		span_create_empty(stream, append_offset, remaining_size - SPAN_EMPTY_METADATA_SIZE);
+		span_create_empty(&stream->data, append_offset, remaining_size - SPAN_EMPTY_METADATA_SIZE);
 	}
 
 	__atomic_store_n(&region_runtime->state, REGION_RUNTIME_STATE_CLEAR, __ATOMIC_RELEASE);

--- a/src/span.c
+++ b/src/span.c
@@ -7,69 +7,70 @@
 
 #include "libpmemstream_internal.h"
 
-const span_bytes *span_offset_to_span_ptr(const struct pmemstream *stream, uint64_t offset)
+const span_bytes *span_offset_to_span_ptr(const struct pmemstream_data_runtime *data, uint64_t offset)
 {
 	assert(offset % sizeof(span_bytes) == 0);
 
-	return (const span_bytes *)pmemstream_offset_to_ptr(stream, offset);
+	return (const span_bytes *)pmemstream_offset_to_ptr(data, offset);
 }
 
 /* Creates empty span at given offset.
  * It sets empty's type and size, and zeros out the whole span.
  */
-void span_create_empty(struct pmemstream *stream, uint64_t offset, size_t size)
+void span_create_empty(struct pmemstream_data_runtime *data, uint64_t offset, size_t size)
 {
-	span_bytes *span = (span_bytes *)span_offset_to_span_ptr(stream, offset);
+	span_bytes *span = (span_bytes *)span_offset_to_span_ptr(data, offset);
 	assert((size & SPAN_TYPE_MASK) == 0);
 	span[0] = size | SPAN_EMPTY;
 
 	void *dest = ((uint8_t *)span) + SPAN_EMPTY_METADATA_SIZE;
-	stream->memset(dest, 0, size, PMEM2_F_MEM_NONTEMPORAL | PMEM2_F_MEM_NODRAIN);
-	stream->persist(span, SPAN_EMPTY_METADATA_SIZE);
+	data->memset(dest, 0, size, PMEM2_F_MEM_NONTEMPORAL | PMEM2_F_MEM_NODRAIN);
+	data->persist(span, SPAN_EMPTY_METADATA_SIZE);
 }
 
 /* Internal helper for span_create_entry. */
-static void span_create_entry_internal(struct pmemstream *stream, uint64_t offset, size_t data_size, size_t popcount,
-				       size_t flush_size)
+static void span_create_entry_internal(struct pmemstream_data_runtime *data, uint64_t offset, size_t data_size,
+				       size_t popcount, size_t flush_size)
 {
-	span_bytes *span = (span_bytes *)span_offset_to_span_ptr(stream, offset);
+	span_bytes *span = (span_bytes *)span_offset_to_span_ptr(data, offset);
 	assert((data_size & SPAN_TYPE_MASK) == 0);
 
 	// XXX - use variadic mempcy to store data and metadata at once
 	span[0] = data_size | SPAN_ENTRY;
 	span[1] = popcount;
 
-	stream->persist(span, flush_size);
+	data->persist(span, flush_size);
 }
 
 /* Creates entry span at given offset.
  * It sets entry's metadata: type, size of the data and popcount.
  * It flushes metadata along with the data (of given 'data_size'), which are stored in the spans following metadata.
  */
-void span_create_entry(struct pmemstream *stream, uint64_t offset, size_t data_size, size_t popcount)
+void span_create_entry(struct pmemstream_data_runtime *data, uint64_t offset, size_t data_size, size_t popcount)
 {
-	span_create_entry_internal(stream, offset, data_size, popcount, SPAN_ENTRY_METADATA_SIZE + data_size);
+	span_create_entry_internal(data, offset, data_size, popcount, SPAN_ENTRY_METADATA_SIZE + data_size);
 }
 
 /* Creates entry span at given offset.
  * It sets entry's metadata: type, size of the data and popcount.
  * It flushes only the metadata.
  */
-void span_create_entry_no_flush_data(struct pmemstream *stream, uint64_t offset, size_t data_size, size_t popcount)
+void span_create_entry_no_flush_data(struct pmemstream_data_runtime *data, uint64_t offset, size_t data_size,
+				     size_t popcount)
 {
-	span_create_entry_internal(stream, offset, data_size, popcount, SPAN_ENTRY_METADATA_SIZE);
+	span_create_entry_internal(data, offset, data_size, popcount, SPAN_ENTRY_METADATA_SIZE);
 }
 
 /* Creates region span at given offset.
  * It only sets region's type and size.
  */
-void span_create_region(struct pmemstream *stream, uint64_t offset, size_t size)
+void span_create_region(struct pmemstream_data_runtime *data, uint64_t offset, size_t size)
 {
-	span_bytes *span = (span_bytes *)span_offset_to_span_ptr(stream, offset);
+	span_bytes *span = (span_bytes *)span_offset_to_span_ptr(data, offset);
 	assert((size & SPAN_TYPE_MASK) == 0);
 	span[0] = size | SPAN_REGION;
 
-	stream->persist(span, SPAN_REGION_METADATA_SIZE);
+	data->persist(span, SPAN_REGION_METADATA_SIZE);
 }
 
 uint64_t span_get_size(const span_bytes *span)
@@ -82,9 +83,9 @@ enum span_type span_get_type(const span_bytes *span)
 	return span[0] & SPAN_TYPE_MASK;
 }
 
-struct span_runtime span_get_empty_runtime(const struct pmemstream *stream, uint64_t offset)
+struct span_runtime span_get_empty_runtime(const struct pmemstream_data_runtime *data, uint64_t offset)
 {
-	const span_bytes *span = span_offset_to_span_ptr(stream, offset);
+	const span_bytes *span = span_offset_to_span_ptr(data, offset);
 	struct span_runtime srt;
 
 	srt.type = SPAN_EMPTY;
@@ -95,9 +96,9 @@ struct span_runtime span_get_empty_runtime(const struct pmemstream *stream, uint
 	return srt;
 }
 
-struct span_runtime span_get_entry_runtime(const struct pmemstream *stream, uint64_t offset)
+struct span_runtime span_get_entry_runtime(const struct pmemstream_data_runtime *data, uint64_t offset)
 {
-	const span_bytes *span = span_offset_to_span_ptr(stream, offset);
+	const span_bytes *span = span_offset_to_span_ptr(data, offset);
 	struct span_runtime srt;
 
 	srt.type = SPAN_ENTRY;
@@ -109,9 +110,9 @@ struct span_runtime span_get_entry_runtime(const struct pmemstream *stream, uint
 	return srt;
 }
 
-struct span_runtime span_get_region_runtime(const struct pmemstream *stream, uint64_t offset)
+struct span_runtime span_get_region_runtime(const struct pmemstream_data_runtime *data, uint64_t offset)
 {
-	const span_bytes *span = span_offset_to_span_ptr(stream, offset);
+	const span_bytes *span = span_offset_to_span_ptr(data, offset);
 	struct span_runtime srt;
 
 	srt.type = SPAN_REGION;
@@ -122,20 +123,20 @@ struct span_runtime span_get_region_runtime(const struct pmemstream *stream, uin
 	return srt;
 }
 
-struct span_runtime span_get_runtime(const struct pmemstream *stream, uint64_t offset)
+struct span_runtime span_get_runtime(const struct pmemstream_data_runtime *data, uint64_t offset)
 {
-	const span_bytes *span = span_offset_to_span_ptr(stream, offset);
+	const span_bytes *span = span_offset_to_span_ptr(data, offset);
 	struct span_runtime srt;
 
 	switch (span_get_type(span)) {
 		case SPAN_EMPTY:
-			srt = span_get_empty_runtime(stream, offset);
+			srt = span_get_empty_runtime(data, offset);
 			break;
 		case SPAN_ENTRY:
-			srt = span_get_entry_runtime(stream, offset);
+			srt = span_get_entry_runtime(data, offset);
 			break;
 		case SPAN_REGION:
-			srt = span_get_region_runtime(stream, offset);
+			srt = span_get_region_runtime(data, offset);
 			break;
 		default:
 			srt.type = SPAN_UNKNOWN;

--- a/src/span.h
+++ b/src/span.h
@@ -64,27 +64,29 @@ struct span_runtime {
 #define SPAN_ENTRY_METADATA_SIZE (MEMBER_SIZE(span_runtime, entry))
 
 typedef uint64_t span_bytes;
+struct pmemstream_data_runtime;
 
 /* Convert offset to pointer to span. offset must be 8-bytes aligned. */
-const span_bytes *span_offset_to_span_ptr(const struct pmemstream *stream, uint64_t offset);
+const span_bytes *span_offset_to_span_ptr(const struct pmemstream_data_runtime *data, uint64_t offset);
 
 /* Those functions create appropriate span at specified offset. offset must be 8-bytes aligned. */
-void span_create_empty(struct pmemstream *stream, uint64_t offset, size_t data_size);
-void span_create_entry(struct pmemstream *stream, uint64_t offset, size_t data_size, size_t popcount);
-void span_create_entry_no_flush_data(struct pmemstream *stream, uint64_t offset, size_t data_size, size_t popcount);
-void span_create_region(struct pmemstream *stream, uint64_t offset, size_t size);
+void span_create_empty(struct pmemstream_data_runtime *data, uint64_t offset, size_t data_size);
+void span_create_entry(struct pmemstream_data_runtime *data, uint64_t offset, size_t data_size, size_t popcount);
+void span_create_entry_no_flush_data(struct pmemstream_data_runtime *data, uint64_t offset, size_t data_size,
+				     size_t popcount);
+void span_create_region(struct pmemstream_data_runtime *data, uint64_t offset, size_t size);
 
 uint64_t span_get_size(const span_bytes *span);
 enum span_type span_get_type(const span_bytes *span);
 
 /* Obtain span_runtime structure describing span at 'offset'. offset must be 8-bytes aligned. */
-struct span_runtime span_get_runtime(const struct pmemstream *stream, uint64_t offset);
+struct span_runtime span_get_runtime(const struct pmemstream_data_runtime *data, uint64_t offset);
 
 /* Works similar to the function above but span must be of certain type. Does not verify if span type at 'offset'
  * is correct. */
-struct span_runtime span_get_empty_runtime(const struct pmemstream *stream, uint64_t offset);
-struct span_runtime span_get_entry_runtime(const struct pmemstream *stream, uint64_t offset);
-struct span_runtime span_get_region_runtime(const struct pmemstream *stream, uint64_t offset);
+struct span_runtime span_get_empty_runtime(const struct pmemstream_data_runtime *data, uint64_t offset);
+struct span_runtime span_get_entry_runtime(const struct pmemstream_data_runtime *data, uint64_t offset);
+struct span_runtime span_get_region_runtime(const struct pmemstream_data_runtime *data, uint64_t offset);
 
 #ifdef __cplusplus
 } /* end extern "C" */

--- a/tests/layout/iterate_validation.cpp
+++ b/tests/layout/iterate_validation.cpp
@@ -80,7 +80,7 @@ int main(int argc, char *argv[])
 
 					pmemstream_entry_iterator_delete(&eiter);
 					/* This pointer is not safe to read - it points to uninitialized data */
-					auto data_ptr = reinterpret_cast<char *>(stream->spans) + entry.offset;
+					auto data_ptr = reinterpret_cast<char *>(stream->data.spans) + entry.offset;
 
 					auto partial_span =
 						generate_inconsistent_span(entry_span ? SPAN_ENTRY : SPAN_EMPTY);

--- a/tests/unittest/reserve_publish.cpp
+++ b/tests/unittest/reserve_publish.cpp
@@ -104,7 +104,7 @@ int main(int argc, char *argv[])
 
 						 std::memcpy(reinterpret_cast<char *>(reserved_data),
 							     extra_entry.data(), extra_entry.size());
-						 stream->persist(reserved_data, extra_entry.size());
+						 stream->data.persist(reserved_data, extra_entry.size());
 						 verify(stream.get(), region, data, {});
 					 }
 					 {


### PR DESCRIPTION
And accept this structure directly in span_* functions. This
removes span dependency on pmemstream structure and allows for
better unittests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemstream/123)
<!-- Reviewable:end -->
