### PR TITLE
Expose structures for specific spans

### DIFF
--- a/src/iterator.c
+++ b/src/iterator.c
@@ -27,20 +27,18 @@ int pmemstream_region_iterator_new(struct pmemstream_region_iterator **iterator,
 
 int pmemstream_region_iterator_next(struct pmemstream_region_iterator *it, struct pmemstream_region *region)
 {
-	struct span_runtime srt;
-
 	while (it->region.offset < it->stream->usable_size) {
-		srt = span_get_runtime(&it->stream->data, it->region.offset);
+		const struct span_base *span_base = span_offset_to_span_ptr(&it->stream->data, it->region.offset);
 
-		if (srt.type == SPAN_REGION) {
+		if (span_get_type(span_base) == SPAN_REGION) {
 			*region = it->region;
-			it->region.offset += srt.total_size;
+			it->region.offset += span_get_total_size(span_base);
 			return 0;
 		}
 
 		/* if there are no more regions we should expect an empty span */
-		assert(srt.type == SPAN_EMPTY);
-		it->region.offset += srt.total_size;
+		assert(span_get_type(span_base) == SPAN_EMPTY);
+		it->region.offset += span_get_total_size(span_base);
 	}
 
 	return -1;
@@ -58,16 +56,17 @@ int entry_iterator_initialize(struct pmemstream_entry_iterator *iterator, struct
 			      struct pmemstream_region region,
 			      region_runtime_initialize_fn_type region_runtime_initialize_fn)
 {
-	struct span_runtime region_srt = span_get_region_runtime(&stream->data, region.offset);
-	struct pmemstream_region_runtime *region_rt;
+	const struct span_base *span_base = span_offset_to_span_ptr(&stream->data, region.offset);
+	assert(span_get_type(span_base) == SPAN_REGION);
 
+	struct pmemstream_region_runtime *region_rt;
 	int ret = region_runtimes_map_get_or_create(stream->region_runtimes_map, region, &region_rt);
 	if (ret) {
 		return ret;
 	}
 
 	struct pmemstream_entry_iterator iter = {.stream = stream,
-						 .offset = region_srt.data_offset,
+						 .offset = region.offset + offsetof(struct span_region, data),
 						 .region = region,
 						 .region_runtime = region_rt,
 						 .region_runtime_initialize_fn = region_runtime_initialize_fn};
@@ -104,9 +103,14 @@ static int validate_entry(const struct pmemstream *stream, struct pmemstream_ent
 	 * before calling this function region_runtime is in UNINITIALIZED state but some other thread
 	 * changes it to CLEAR while span metadata is read. We might fix this using Optimistic Concurrency
 	 * Control (using region_runtime state). */
-	struct span_runtime srt = span_get_runtime(&stream->data, entry.offset);
-	const void *entry_data = pmemstream_offset_to_ptr(&stream->data, srt.data_offset);
-	if (srt.type == SPAN_ENTRY && util_popcount_memory(entry_data, srt.entry.size) == srt.entry.popcount) {
+	const struct span_base *span_base = span_offset_to_span_ptr(&stream->data, entry.offset);
+	if (span_get_type(span_base) != SPAN_ENTRY) {
+		return -1;
+	}
+
+	const struct span_entry *span_entry = (const struct span_entry *)span_base;
+	const void *entry_data = span_entry->data;
+	if (util_popcount_memory(entry_data, span_get_size(span_base)) == span_entry->popcount) {
 		return 0;
 	}
 	return -1;
@@ -114,8 +118,8 @@ static int validate_entry(const struct pmemstream *stream, struct pmemstream_ent
 
 static bool pmemstream_entry_iterator_offset_is_inside_region(struct pmemstream_entry_iterator *iterator)
 {
-	struct span_runtime region_srt = span_get_region_runtime(&iterator->stream->data, iterator->region.offset);
-	uint64_t region_end_offset = iterator->region.offset + region_srt.total_size;
+	const struct span_base *span_base = span_offset_to_span_ptr(&iterator->stream->data, iterator->region.offset);
+	uint64_t region_end_offset = iterator->region.offset + span_get_total_size(span_base);
 	return iterator->offset >= iterator->region.offset && iterator->offset <= region_end_offset;
 }
 
@@ -145,8 +149,8 @@ static bool pmemstream_entry_iterator_offset_at_valid_entry(struct pmemstream_en
 {
 	assert(pmemstream_entry_iterator_offset_is_inside_region(iterator));
 
-	struct span_runtime region_srt = span_get_region_runtime(&iterator->stream->data, iterator->region.offset);
-	uint64_t region_end_offset = iterator->region.offset + region_srt.total_size;
+	const struct span_base *span_base = span_offset_to_span_ptr(&iterator->stream->data, iterator->region.offset);
+	uint64_t region_end_offset = iterator->region.offset + span_get_total_size(span_base);
 	struct pmemstream_entry entry = {.offset = iterator->offset};
 
 	return iterator->offset < region_end_offset && validate_entry(iterator->stream, entry) == 0;
@@ -158,8 +162,8 @@ static void pmemstream_entry_iterator_advance(struct pmemstream_entry_iterator *
 	 * increment - those checks should not fail unless stream was corrupted. */
 	assert(pmemstream_entry_iterator_offset_is_inside_region(iterator));
 
-	struct span_runtime entry_srt = span_get_entry_runtime(&iterator->stream->data, iterator->offset);
-	iterator->offset += entry_srt.total_size;
+	const struct span_base *span_base = span_offset_to_span_ptr(&iterator->stream->data, iterator->offset);
+	iterator->offset += span_get_total_size(span_base);
 
 	assert(pmemstream_entry_iterator_offset_is_inside_region(iterator));
 }

--- a/src/libpmemstream.c
+++ b/src/libpmemstream.c
@@ -32,7 +32,13 @@ static void pmemstream_init(struct pmemstream *stream)
 	stream->data.memset(stream->header->signature, 0, PMEMSTREAM_SIGNATURE_SIZE,
 			    PMEM2_F_MEM_NONTEMPORAL | PMEM2_F_MEM_NODRAIN);
 
-	span_create_empty(&stream->data, 0, stream->usable_size - SPAN_EMPTY_METADATA_SIZE);
+	size_t empty_size = stream->usable_size - sizeof(struct span_empty);
+	struct span_empty span_empty = {.span_base = span_base_create(empty_size, SPAN_EMPTY)};
+
+	uint8_t *destination = (uint8_t *)span_offset_to_span_ptr(&stream->data, 0);
+	stream->data.memcpy(destination, &span_empty, sizeof(span_empty), PMEM2_F_MEM_NODRAIN);
+	stream->data.memset(destination + sizeof(span_empty), 0, empty_size,
+			    PMEM2_F_MEM_NONTEMPORAL | PMEM2_F_MEM_NODRAIN);
 
 	stream->header->stream_size = stream->stream_size;
 	stream->header->block_size = stream->block_size;
@@ -82,7 +88,7 @@ static int pmemstream_validate_sizes(size_t block_size, struct pmem2_map *map)
 		return -1;
 	}
 
-	if (pmemstream_usable_size(stream_size, block_size) <= SPAN_REGION_METADATA_SIZE) {
+	if (pmemstream_usable_size(stream_size, block_size) <= sizeof(struct span_region)) {
 		return -1;
 	}
 
@@ -149,9 +155,9 @@ int pmemstream_region_allocate(struct pmemstream *stream, size_t size, struct pm
 {
 	const uint64_t offset = 0;
 	assert(offset % stream->block_size == 0);
-	struct span_runtime srt = span_get_runtime(&stream->data, offset);
+	const struct span_base *span_base = span_offset_to_span_ptr(&stream->data, offset);
 
-	if (srt.type != SPAN_EMPTY) {
+	if (span_get_type(span_base) != SPAN_EMPTY) {
 		return -1;
 	}
 
@@ -159,37 +165,43 @@ int pmemstream_region_allocate(struct pmemstream *stream, size_t size, struct pm
 		return -1;
 	}
 
-	size_t total_size = ALIGN_UP(size + SPAN_REGION_METADATA_SIZE, stream->block_size);
-	if (total_size > srt.empty.size + SPAN_EMPTY_METADATA_SIZE)
+	struct span_region span_region = {.span_base = span_base_create(size, SPAN_REGION)};
+
+	size_t total_size = ALIGN_UP(span_get_total_size(&span_region.span_base), stream->block_size);
+	if (total_size > span_get_total_size(span_base))
 		return -1;
 
-	span_create_region(&stream->data, offset, total_size - SPAN_REGION_METADATA_SIZE);
+	stream->data.memcpy((void *)span_base, &span_region, sizeof(struct span_region), 0);
 	region->offset = offset;
 
+#ifndef NDEBUG
+	struct span_region *stored_span_region = (struct span_region *)span_base;
 	/* XXX: use CACHELINE_SIZE instead of 64 */
-	assert(((uintptr_t)pmemstream_offset_to_ptr(&stream->data,
-						    span_get_runtime(&stream->data, offset).data_offset)) %
-		       64 ==
-	       0);
+	assert(((uintptr_t)stored_span_region->data) % 64 == 0);
+#endif
 
 	return 0;
 }
 
 size_t pmemstream_region_size(struct pmemstream *stream, struct pmemstream_region region)
 {
-	struct span_runtime region_srt = span_get_region_runtime(&stream->data, region.offset);
-
-	return region_srt.region.size;
+	const struct span_base *span_region = span_offset_to_span_ptr(&stream->data, region.offset);
+	assert(span_get_type(span_region) == SPAN_REGION);
+	return span_get_size(span_region);
 }
 
 int pmemstream_region_free(struct pmemstream *stream, struct pmemstream_region region)
 {
-	struct span_runtime srt = span_get_runtime(&stream->data, region.offset);
+	struct span_region *span_region = (struct span_region *)span_offset_to_span_ptr(&stream->data, region.offset);
 
-	if (srt.type != SPAN_REGION)
+	if (span_get_type(&span_region->span_base) != SPAN_REGION)
 		return -1;
 
-	span_create_empty(&stream->data, 0, stream->usable_size - SPAN_EMPTY_METADATA_SIZE);
+	uint8_t *destination = (uint8_t *)span_region;
+	size_t empty_size = stream->usable_size - sizeof(struct span_empty);
+	struct span_empty span_empty = {.span_base = span_base_create(empty_size, SPAN_EMPTY)};
+	stream->data.memcpy(destination, &span_empty, sizeof(span_empty), PMEM2_F_MEM_NODRAIN);
+	stream->data.memset(destination + sizeof(span_empty), 0, empty_size, PMEM2_F_MEM_NONTEMPORAL);
 
 	region_runtimes_map_remove(stream->region_runtimes_map, region);
 
@@ -199,17 +211,15 @@ int pmemstream_region_free(struct pmemstream *stream, struct pmemstream_region r
 // returns pointer to the data of the entry
 const void *pmemstream_entry_data(struct pmemstream *stream, struct pmemstream_entry entry)
 {
-	struct span_runtime entry_srt = span_get_entry_runtime(&stream->data, entry.offset);
-
-	return pmemstream_offset_to_ptr(&stream->data, entry_srt.data_offset);
+	struct span_entry *span_entry = (struct span_entry *)span_offset_to_span_ptr(&stream->data, entry.offset);
+	return span_entry->data;
 }
 
 // returns the size of the entry
 size_t pmemstream_entry_length(struct pmemstream *stream, struct pmemstream_entry entry)
 {
-	struct span_runtime entry_srt = span_get_entry_runtime(&stream->data, entry.offset);
-
-	return entry_srt.entry.size;
+	struct span_entry *span_entry = (struct span_entry *)span_offset_to_span_ptr(&stream->data, entry.offset);
+	return span_get_size(&span_entry->span_base);
 }
 
 int pmemstream_region_runtime_initialize(struct pmemstream *stream, struct pmemstream_region region,
@@ -227,8 +237,8 @@ int pmemstream_region_runtime_initialize(struct pmemstream *stream, struct pmems
 
 static size_t pmemstream_entry_total_size_aligned(size_t size)
 {
-	size_t entry_total_size = size + SPAN_ENTRY_METADATA_SIZE;
-	return ALIGN_UP(entry_total_size, sizeof(span_bytes));
+	struct span_entry span_entry = {.span_base = span_base_create(size, SPAN_ENTRY)};
+	return span_get_total_size(&span_entry.span_base);
 }
 
 int pmemstream_reserve(struct pmemstream *stream, struct pmemstream_region region,
@@ -236,7 +246,8 @@ int pmemstream_reserve(struct pmemstream *stream, struct pmemstream_region regio
 		       struct pmemstream_entry *reserved_entry, void **data_addr)
 {
 	size_t entry_total_size_span_aligned = pmemstream_entry_total_size_aligned(size);
-	struct span_runtime region_srt = span_get_region_runtime(&stream->data, region.offset);
+	const struct span_base *span_region = span_offset_to_span_ptr(&stream->data, region.offset);
+	assert(span_get_type(span_region) == SPAN_REGION);
 	int ret = 0;
 
 	if (!region_runtime) {
@@ -247,12 +258,8 @@ int pmemstream_reserve(struct pmemstream *stream, struct pmemstream_region regio
 	}
 
 	uint64_t offset = region_runtime_get_append_offset_acquire(region_runtime);
-	assert(offset >= region_srt.data_offset);
-	if (offset + entry_total_size_span_aligned > region.offset + region_srt.total_size) {
-		return -1;
-	}
-	/* offset outside of region */
-	if (offset < region_srt.data_offset) {
+	assert(offset >= region.offset + offsetof(struct span_region, data));
+	if (offset + entry_total_size_span_aligned > region.offset + span_get_total_size(span_region)) {
 		return -1;
 	}
 
@@ -260,7 +267,7 @@ int pmemstream_reserve(struct pmemstream *stream, struct pmemstream_region regio
 
 	reserved_entry->offset = offset;
 	/* data is right after the entry metadata */
-	*data_addr = (void *)span_offset_to_span_ptr(&stream->data, offset + SPAN_ENTRY_METADATA_SIZE);
+	*data_addr = (void *)span_offset_to_span_ptr(&stream->data, offset + sizeof(struct span_entry));
 
 	return ret;
 }
@@ -276,7 +283,14 @@ int pmemstream_publish(struct pmemstream *stream, struct pmemstream_region regio
 		}
 	}
 
-	span_create_entry(&stream->data, reserved_entry->offset, size, util_popcount_memory(data, size));
+	struct span_entry span_entry = {.span_base = span_base_create(size, SPAN_ENTRY),
+					.popcount = util_popcount_memory(data, size)};
+
+	uint8_t *destination = (uint8_t *)span_offset_to_span_ptr(&stream->data, reserved_entry->offset);
+	stream->data.memcpy(destination, &span_entry, sizeof(span_entry), PMEM2_F_MEM_NOFLUSH);
+	/* 'data' is already copied - we only need to persist. */
+	stream->data.persist(destination, pmemstream_entry_total_size_aligned(size));
+
 	region_runtime_increase_committed_offset(region_runtime, pmemstream_entry_total_size_aligned(size));
 
 	return 0;
@@ -301,8 +315,14 @@ int pmemstream_append(struct pmemstream *stream, struct pmemstream_region region
 		return ret;
 	}
 
-	stream->data.memcpy(reserved_dest, data, size, PMEM2_F_MEM_NODRAIN);
-	span_create_entry_no_flush_data(&stream->data, reserved_entry.offset, size, util_popcount_memory(data, size));
+	struct span_entry span_entry = {.span_base = span_base_create(size, SPAN_ENTRY),
+					.popcount = util_popcount_memory(data, size)};
+
+	uint8_t *destination = (uint8_t *)span_offset_to_span_ptr(&stream->data, reserved_entry.offset);
+	stream->data.memcpy(destination, &span_entry, sizeof(span_entry), PMEM2_F_MEM_NOFLUSH);
+	stream->data.memcpy(destination + sizeof(span_entry), data, size, PMEM2_F_MEM_NOFLUSH);
+	stream->data.persist(destination, pmemstream_entry_total_size_aligned(size));
+
 	region_runtime_increase_committed_offset(region_runtime, pmemstream_entry_total_size_aligned(size));
 
 	if (new_entry) {

--- a/src/libpmemstream_internal.h
+++ b/src/libpmemstream_internal.h
@@ -6,6 +6,8 @@
 #ifndef LIBPMEMSTREAM_INTERNAL_H
 #define LIBPMEMSTREAM_INTERNAL_H
 
+#include <assert.h>
+
 #include "iterator.h"
 #include "libpmemstream.h"
 #include "region.h"
@@ -51,6 +53,14 @@ struct pmemstream {
 static inline const uint8_t *pmemstream_offset_to_ptr(const struct pmemstream_data_runtime *data, uint64_t offset)
 {
 	return (const uint8_t *)data->spans + offset;
+}
+
+/* Convert offset to pointer to span. offset must be 8-bytes aligned. */
+static inline const struct span_base *span_offset_to_span_ptr(const struct pmemstream_data_runtime *data,
+							      uint64_t offset)
+{
+	assert(offset % sizeof(struct span_base) == 0);
+	return (const struct span_base *)pmemstream_offset_to_ptr(data, offset);
 }
 
 #ifdef __cplusplus

--- a/src/region.c
+++ b/src/region.c
@@ -238,12 +238,19 @@ static void region_runtime_clear_from_tail(struct pmemstream *stream, struct pme
 	assert(region_runtime_get_state_acquire(region_runtime) == REGION_RUNTIME_STATE_DIRTY);
 
 	uint64_t append_offset = region_runtime_get_append_offset_acquire(region_runtime);
-	struct span_runtime region_rt = span_get_region_runtime(&stream->data, region.offset);
-	size_t region_end_offset = region.offset + region_rt.total_size;
+	const struct span_base *span_base = span_offset_to_span_ptr(&stream->data, region.offset);
+	size_t region_end_offset = region.offset + span_get_total_size(span_base);
 	size_t remaining_size = region_end_offset - append_offset;
 
 	if (remaining_size != 0) {
-		span_create_empty(&stream->data, append_offset, remaining_size - SPAN_EMPTY_METADATA_SIZE);
+		struct span_empty span_empty = {
+			.span_base = span_base_create(remaining_size - sizeof(span_empty), SPAN_EMPTY)};
+
+		uint8_t *destination = (uint8_t *)span_offset_to_span_ptr(&stream->data, append_offset);
+		stream->data.memcpy(destination, &span_empty, sizeof(span_empty), PMEM2_F_MEM_NOFLUSH);
+		stream->data.memset(destination + sizeof(span_empty), 0, remaining_size - sizeof(span_empty),
+				    PMEM2_F_MEM_NONTEMPORAL | PMEM2_F_MEM_NODRAIN);
+		stream->data.persist(destination, sizeof(span_empty));
 	}
 
 	__atomic_store_n(&region_runtime->state, REGION_RUNTIME_STATE_CLEAR, __ATOMIC_RELEASE);

--- a/src/span.c
+++ b/src/span.c
@@ -5,144 +5,42 @@
 
 #include <assert.h>
 
-#include "libpmemstream_internal.h"
+#include "common/util.h"
 
-const span_bytes *span_offset_to_span_ptr(const struct pmemstream_data_runtime *data, uint64_t offset)
+struct span_base span_base_create(uint64_t size, enum span_type type)
 {
-	assert(offset % sizeof(span_bytes) == 0);
-
-	return (const span_bytes *)pmemstream_offset_to_ptr(data, offset);
-}
-
-/* Creates empty span at given offset.
- * It sets empty's type and size, and zeros out the whole span.
- */
-void span_create_empty(struct pmemstream_data_runtime *data, uint64_t offset, size_t size)
-{
-	span_bytes *span = (span_bytes *)span_offset_to_span_ptr(data, offset);
 	assert((size & SPAN_TYPE_MASK) == 0);
-	span[0] = size | SPAN_EMPTY;
+	struct span_base span = {.size_and_type = size | type};
+	return span;
+};
 
-	void *dest = ((uint8_t *)span) + SPAN_EMPTY_METADATA_SIZE;
-	data->memset(dest, 0, size, PMEM2_F_MEM_NONTEMPORAL | PMEM2_F_MEM_NODRAIN);
-	data->persist(span, SPAN_EMPTY_METADATA_SIZE);
+uint64_t span_get_size(const struct span_base *span)
+{
+	return span->size_and_type & SPAN_EXTRA_MASK;
 }
 
-/* Internal helper for span_create_entry. */
-static void span_create_entry_internal(struct pmemstream_data_runtime *data, uint64_t offset, size_t data_size,
-				       size_t popcount, size_t flush_size)
+size_t span_get_total_size(const struct span_base *span)
 {
-	span_bytes *span = (span_bytes *)span_offset_to_span_ptr(data, offset);
-	assert((data_size & SPAN_TYPE_MASK) == 0);
-
-	// XXX - use variadic mempcy to store data and metadata at once
-	span[0] = data_size | SPAN_ENTRY;
-	span[1] = popcount;
-
-	data->persist(span, flush_size);
-}
-
-/* Creates entry span at given offset.
- * It sets entry's metadata: type, size of the data and popcount.
- * It flushes metadata along with the data (of given 'data_size'), which are stored in the spans following metadata.
- */
-void span_create_entry(struct pmemstream_data_runtime *data, uint64_t offset, size_t data_size, size_t popcount)
-{
-	span_create_entry_internal(data, offset, data_size, popcount, SPAN_ENTRY_METADATA_SIZE + data_size);
-}
-
-/* Creates entry span at given offset.
- * It sets entry's metadata: type, size of the data and popcount.
- * It flushes only the metadata.
- */
-void span_create_entry_no_flush_data(struct pmemstream_data_runtime *data, uint64_t offset, size_t data_size,
-				     size_t popcount)
-{
-	span_create_entry_internal(data, offset, data_size, popcount, SPAN_ENTRY_METADATA_SIZE);
-}
-
-/* Creates region span at given offset.
- * It only sets region's type and size.
- */
-void span_create_region(struct pmemstream_data_runtime *data, uint64_t offset, size_t size)
-{
-	span_bytes *span = (span_bytes *)span_offset_to_span_ptr(data, offset);
-	assert((size & SPAN_TYPE_MASK) == 0);
-	span[0] = size | SPAN_REGION;
-
-	data->persist(span, SPAN_REGION_METADATA_SIZE);
-}
-
-uint64_t span_get_size(const span_bytes *span)
-{
-	return span[0] & SPAN_EXTRA_MASK;
-}
-
-enum span_type span_get_type(const span_bytes *span)
-{
-	return span[0] & SPAN_TYPE_MASK;
-}
-
-struct span_runtime span_get_empty_runtime(const struct pmemstream_data_runtime *data, uint64_t offset)
-{
-	const span_bytes *span = span_offset_to_span_ptr(data, offset);
-	struct span_runtime srt;
-
-	srt.type = SPAN_EMPTY;
-	srt.empty.size = span_get_size(span);
-	srt.data_offset = offset + SPAN_EMPTY_METADATA_SIZE;
-	srt.total_size = ALIGN_UP(srt.empty.size + SPAN_EMPTY_METADATA_SIZE, sizeof(span_bytes));
-
-	return srt;
-}
-
-struct span_runtime span_get_entry_runtime(const struct pmemstream_data_runtime *data, uint64_t offset)
-{
-	const span_bytes *span = span_offset_to_span_ptr(data, offset);
-	struct span_runtime srt;
-
-	srt.type = SPAN_ENTRY;
-	srt.entry.size = span_get_size(span);
-	srt.entry.popcount = span[1];
-	srt.data_offset = offset + SPAN_ENTRY_METADATA_SIZE;
-	srt.total_size = ALIGN_UP(srt.entry.size + SPAN_ENTRY_METADATA_SIZE, sizeof(span_bytes));
-
-	return srt;
-}
-
-struct span_runtime span_get_region_runtime(const struct pmemstream_data_runtime *data, uint64_t offset)
-{
-	const span_bytes *span = span_offset_to_span_ptr(data, offset);
-	struct span_runtime srt;
-
-	srt.type = SPAN_REGION;
-	srt.region.size = span_get_size(span);
-	srt.data_offset = offset + SPAN_REGION_METADATA_SIZE;
-	srt.total_size = ALIGN_UP(srt.region.size + SPAN_REGION_METADATA_SIZE, sizeof(span_bytes));
-
-	return srt;
-}
-
-struct span_runtime span_get_runtime(const struct pmemstream_data_runtime *data, uint64_t offset)
-{
-	const span_bytes *span = span_offset_to_span_ptr(data, offset);
-	struct span_runtime srt;
-
+	size_t size = span_get_size(span);
 	switch (span_get_type(span)) {
 		case SPAN_EMPTY:
-			srt = span_get_empty_runtime(data, offset);
+			size += sizeof(struct span_empty);
 			break;
 		case SPAN_ENTRY:
-			srt = span_get_entry_runtime(data, offset);
+			size += sizeof(struct span_entry);
 			break;
 		case SPAN_REGION:
-			srt = span_get_region_runtime(data, offset);
+			size += sizeof(struct span_region);
 			break;
 		default:
-			srt.type = SPAN_UNKNOWN;
-			srt.data_offset = offset;
-			srt.total_size = 0;
+			break;
 	}
 
-	return srt;
+	/* Align so that each span starts at sizeof(span_bytes) aligned offset. */
+	return ALIGN_UP(size, sizeof(span_bytes));
+}
+
+enum span_type span_get_type(const struct span_base *span)
+{
+	return span->size_and_type & SPAN_TYPE_MASK;
 }

--- a/src/span.h
+++ b/src/span.h
@@ -6,7 +6,6 @@
 #ifndef LIBPMEMSTREAM_SPAN_H
 #define LIBPMEMSTREAM_SPAN_H
 
-#include "common/util.h"
 #include "libpmemstream.h"
 
 #include <stdint.h>
@@ -18,18 +17,8 @@ extern "C" {
 
 /**
  * Span is a contiguous sequence of bytes, which are located on peristent storage.
- *
- * Span is always 8-bytes aligned. Its first 8 bytes hold information about size and type of a span. Type can be one
- * of the following:
- * - region
- * - entry
- * - empty space
- *
- * Span can be created using span_create_* family of functions. Access to a span is performed through a helper
- * span_runtime structure which exposes span's type, size and other metadata depending on its type. span_runtime
- * can be obtained from span_get_runtime* family of functions.
+ * Span is always 8-bytes aligned. Its first 8 bytes hold information about size and type of a span.
  */
-
 enum span_type {
 	SPAN_EMPTY = 0b00ULL << 62,
 	SPAN_REGION = 0b11ULL << 62,
@@ -40,53 +29,37 @@ enum span_type {
 #define SPAN_TYPE_MASK (11ULL << 62)
 #define SPAN_EXTRA_MASK (~SPAN_TYPE_MASK)
 
-struct span_runtime {
-	enum span_type type;
-	size_t total_size;
-	uint64_t data_offset;
-	union {
-		struct {
-			uint64_t size;
-		} empty;
-		struct {
-			uint64_t size;
-		} region;
-		struct {
-			uint64_t size;
-			uint64_t popcount;
-		} entry;
-	};
+struct span_base {
+	uint64_t size_and_type;
 };
 
-#define SPAN_EMPTY_METADATA_SIZE (MEMBER_SIZE(span_runtime, empty))
-/* XXX: use CACHELINE_SIZE + static_assert 64 >= MEMBER_SIZE(span_runtime, entry)*/
-#define SPAN_REGION_METADATA_SIZE 64
-#define SPAN_ENTRY_METADATA_SIZE (MEMBER_SIZE(span_runtime, entry))
+struct span_region {
+	struct span_base span_base;
+	uint64_t padding[7]; /* XXX: CACHELINE_SIZE - sizeof(struct span_base) */
+	uint64_t data[];
+};
+
+struct span_entry {
+	struct span_base span_base;
+	uint64_t popcount;
+	uint64_t data[];
+};
+
+struct span_empty {
+	struct span_base span_base;
+};
 
 typedef uint64_t span_bytes;
-struct pmemstream_data_runtime;
 
-/* Convert offset to pointer to span. offset must be 8-bytes aligned. */
-const span_bytes *span_offset_to_span_ptr(const struct pmemstream_data_runtime *data, uint64_t offset);
+struct span_base span_base_create(uint64_t size, enum span_type type);
 
-/* Those functions create appropriate span at specified offset. offset must be 8-bytes aligned. */
-void span_create_empty(struct pmemstream_data_runtime *data, uint64_t offset, size_t data_size);
-void span_create_entry(struct pmemstream_data_runtime *data, uint64_t offset, size_t data_size, size_t popcount);
-void span_create_entry_no_flush_data(struct pmemstream_data_runtime *data, uint64_t offset, size_t data_size,
-				     size_t popcount);
-void span_create_region(struct pmemstream_data_runtime *data, uint64_t offset, size_t size);
+/* Returns size of the span's data - excluding size of the span structure itself. */
+size_t span_get_size(const struct span_base *span);
 
-uint64_t span_get_size(const span_bytes *span);
-enum span_type span_get_type(const span_bytes *span);
+/* Returns value of span_get_size(span) + size of the span structure. */
+size_t span_get_total_size(const struct span_base *span);
 
-/* Obtain span_runtime structure describing span at 'offset'. offset must be 8-bytes aligned. */
-struct span_runtime span_get_runtime(const struct pmemstream_data_runtime *data, uint64_t offset);
-
-/* Works similar to the function above but span must be of certain type. Does not verify if span type at 'offset'
- * is correct. */
-struct span_runtime span_get_empty_runtime(const struct pmemstream_data_runtime *data, uint64_t offset);
-struct span_runtime span_get_entry_runtime(const struct pmemstream_data_runtime *data, uint64_t offset);
-struct span_runtime span_get_region_runtime(const struct pmemstream_data_runtime *data, uint64_t offset);
+enum span_type span_get_type(const struct span_base *span);
 
 #ifdef __cplusplus
 } /* end extern "C" */

--- a/tests/layout/iterate_validation.cpp
+++ b/tests/layout/iterate_validation.cpp
@@ -25,9 +25,9 @@ std::vector<uint64_t> generate_inconsistent_span(span_type stype)
 
 	size_t metadata_size = 0;
 	if (stype == SPAN_EMPTY) {
-		metadata_size = SPAN_EMPTY_METADATA_SIZE;
+		metadata_size = sizeof(struct span_empty);
 	} else if (stype == SPAN_ENTRY) {
-		metadata_size = SPAN_ENTRY_METADATA_SIZE;
+		metadata_size = sizeof(struct span_entry);
 	}
 
 	/* Use uint64_t to ensure proper alignment. */

--- a/tests/unittest/create.cpp
+++ b/tests/unittest/create.cpp
@@ -106,7 +106,7 @@ int main(int argc, char *argv[])
 
 			const auto available_size = ALIGN_DOWN(
 				TEST_DEFAULT_STREAM_SIZE - std::max(STREAM_METADATA_SIZE, block_size), block_size);
-			RC_PRE(ALIGN_UP(region_size + SPAN_REGION_METADATA_SIZE, block_size) <= available_size);
+			RC_PRE(ALIGN_UP(region_size + sizeof(struct span_region), block_size) <= available_size);
 
 			auto stream = make_pmemstream(path, block_size, TEST_DEFAULT_STREAM_SIZE);
 			/* and initialize this stream with a single region of */


### PR DESCRIPTION
and remove span_runtime structure. This approach gives more control
to the users and allows to easily manipulate spans that reside on
persistent memory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemstream/125)
<!-- Reviewable:end -->
