### PR TITLE
cmake: get rid of a warning, when opted out from valgrind tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,7 +22,7 @@ endif()
 if(NOT VALGRIND_FOUND AND TESTS_USE_VALGRIND)
 	message(FATAL_ERROR "Valgrind not found, but flag TESTS_USE_VALGRIND was set.")
 elseif(NOT VALGRIND_FOUND)
-	message(WARNING "Valgrind not found. Valgrind tests will not be performed.")
+	message(STATUS "Valgrind not found. Valgrind tests will not be performed.")
 elseif(VALGRIND_FOUND)
 	message(STATUS "Found Valgrind in '${VALGRIND_LIBRARY_DIRS}' (version: ${VALGRIND_VERSION})")
 


### PR DESCRIPTION
It's misleading to get a CMake warning when I didn't enable
TESTS_USE_VALGRIND (and Valgrind wasn't found), it's better to just inform.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemstream/126)
<!-- Reviewable:end -->
