### PR TITLE
Don't compile debug function in release mode

### DIFF
--- a/src/id_manager.c
+++ b/src/id_manager.c
@@ -79,10 +79,12 @@ static bool id_manager_critnib_get_min_key(critnib *ids, uint64_t *key)
 	return id_manager_critnib_get_ge_key(ids, 0, key);
 }
 
+#ifndef NDEBUG
 static bool id_manager_critnib_get_max_key(critnib *ids, uint64_t *key)
 {
 	return id_manager_critnib_get_le_key(ids, UINT64_MAX, key);
 }
+#endif
 
 uint64_t id_manager_acquire(struct id_manager *manager)
 {
@@ -131,6 +133,7 @@ static void id_manager_do_compaction(struct id_manager *manager)
 	}
 }
 
+#ifndef NDEBUG
 static bool id_manager_release_invariants(struct id_manager *manager)
 {
 	uint64_t max_key;
@@ -142,6 +145,7 @@ static bool id_manager_release_invariants(struct id_manager *manager)
 
 	return true;
 }
+#endif
 
 int id_manager_release(struct id_manager *manager, uint64_t id)
 {

--- a/src/iterator.c
+++ b/src/iterator.c
@@ -56,8 +56,7 @@ int entry_iterator_initialize(struct pmemstream_entry_iterator *iterator, struct
 			      struct pmemstream_region region,
 			      region_runtime_initialize_fn_type region_runtime_initialize_fn)
 {
-	const struct span_base *span_base = span_offset_to_span_ptr(&stream->data, region.offset);
-	assert(span_get_type(span_base) == SPAN_REGION);
+	assert(span_get_type(span_offset_to_span_ptr(&stream->data, region.offset)) == SPAN_REGION);
 
 	struct pmemstream_region_runtime *region_rt;
 	int ret = region_runtimes_map_get_or_create(stream->region_runtimes_map, region, &region_rt);
@@ -116,12 +115,14 @@ static int validate_entry(const struct pmemstream *stream, struct pmemstream_ent
 	return -1;
 }
 
+#ifndef NDEBUG
 static bool pmemstream_entry_iterator_offset_is_inside_region(struct pmemstream_entry_iterator *iterator)
 {
 	const struct span_base *span_base = span_offset_to_span_ptr(&iterator->stream->data, iterator->region.offset);
 	uint64_t region_end_offset = iterator->region.offset + span_get_total_size(span_base);
 	return iterator->offset >= iterator->region.offset && iterator->offset <= region_end_offset;
 }
+#endif
 
 /* Precondition: region_runtime is initialized. */
 static bool pmemstream_entry_iterator_offset_is_below_committed(struct pmemstream_entry_iterator *iterator)

--- a/src/region.c
+++ b/src/region.c
@@ -8,7 +8,9 @@
 #include <assert.h>
 #include <errno.h>
 
+#ifndef NDEBUG
 #define PMEMSTREAM_OFFSET_UNINITIALIZED 0ULL
+#endif
 
 /*
  * It contains all runtime data specific to a region.


### PR DESCRIPTION
This PR uses NDEBUG macro to avoid compilation of some functions in release mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemstream/129)
<!-- Reviewable:end -->
