### PR TITLE
Extend iterate_validation test

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -137,7 +137,7 @@ if(TESTS_RAPIDCHECK)
 	add_test_generic(NAME util_common TRACERS none)
 
 	build_test_rc(NAME iterate_validation SRC_FILES layout/iterate_validation.cpp ../src/span.c)
-	add_test_generic(NAME iterate_validation TRACERS none)
+	add_test_generic(NAME iterate_validation TRACERS none memcheck pmemcheck)
 endif()
 
 if(GDB AND DEBUG_BUILD)

--- a/tests/common/stream_helpers.hpp
+++ b/tests/common/stream_helpers.hpp
@@ -54,6 +54,11 @@ struct stream {
 		c_stream.reset();
 	}
 
+	pmemstream *c_ptr()
+	{
+		return c_stream.get();
+	}
+
 	std::tuple<int, struct pmemstream_region_runtime *> region_runtime_initialize(struct pmemstream_region region)
 	{
 		struct pmemstream_region_runtime *runtime = nullptr;


### PR DESCRIPTION
Add test with consistent (manually created) span.
Also change calculating pointer to next_entry. Now, we
just append new entry and overwrite it (along with metadata).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemstream/135)
<!-- Reviewable:end -->
