### PR TITLE
Implement span_runtime for testing purposes

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -48,6 +48,7 @@ add_library(test_backtrace STATIC common/test_backtrace.c)
 if(LIBUNWIND_FOUND)
 	target_compile_definitions(test_backtrace PUBLIC USE_LIBUNWIND=1)
 endif()
+add_library(stream_span_helpers STATIC common/stream_span_helpers.cpp ../src/span.c)
 
 # Set variable to know if debug tests can be run
 if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
@@ -135,6 +136,9 @@ if(TESTS_RAPIDCHECK)
 
 	build_test_rc(NAME util_common SRC_FILES unittest/util_common.cpp)
 	add_test_generic(NAME util_common TRACERS none)
+
+	build_test_rc(NAME iterate_all SRC_FILES layout/iterate_all.cpp ../src/span.c)
+	add_test_generic(NAME iterate_all TRACERS none)
 
 	build_test_rc(NAME iterate_validation SRC_FILES layout/iterate_validation.cpp ../src/span.c)
 	add_test_generic(NAME iterate_validation TRACERS none)

--- a/tests/cmake/functions.cmake
+++ b/tests/cmake/functions.cmake
@@ -182,7 +182,7 @@ function(build_test name)
 	prepend(srcs ${TESTS_ROOT_DIR} ${srcs})
 
 	add_executable(${name} ${srcs})
-	target_link_libraries(${name} ${CMAKE_THREAD_LIBS_INIT} ${LIBPMEM2_LIBRARIES} pmemstream test_backtrace)
+	target_link_libraries(${name} ${CMAKE_THREAD_LIBS_INIT} ${LIBPMEM2_LIBRARIES} pmemstream test_backtrace stream_span_helpers)
 	if(LIBUNWIND_FOUND)
 		target_link_libraries(${name} ${LIBUNWIND_LIBRARIES} ${CMAKE_DL_LIBS})
 	endif()

--- a/tests/common/stream_span_helpers.cpp
+++ b/tests/common/stream_span_helpers.cpp
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2022, Intel Corporation */
+
+#include "stream_span_helpers.hpp"
+
+#include "../src/libpmemstream_internal.h"
+#include "../src/span.h"
+#include "stream_helpers.hpp"
+
+std::vector<span_runtime> span_runtimes_from_stream(const pmem::stream &stream, size_t offset, size_t end_offset)
+{
+	std::vector<span_runtime> spans;
+	auto span_bytes_ptr = reinterpret_cast<const char *>(stream.c_ptr()->data.spans);
+	end_offset = std::min(end_offset, stream.c_ptr()->usable_size);
+
+	while (offset < end_offset) {
+		auto span_base_ptr = reinterpret_cast<const span_base *>(span_bytes_ptr + offset);
+		auto span_type = span_get_type(span_base_ptr);
+		span_runtime sr{offset, span_base_ptr, {}};
+		if (span_type == SPAN_REGION) {
+			sr.sub_spans = span_runtimes_from_stream(stream, offset + sizeof(span_region),
+								 offset + span_get_total_size(span_base_ptr));
+			spans.emplace_back(std::move(sr));
+		} else if (span_type == SPAN_EMPTY && spans.size() && span_get_type(spans.back().ptr) == SPAN_EMPTY) {
+			/* Skip adding multiple, adjacent empty spans. */
+		} else {
+			spans.emplace_back(std::move(sr));
+		}
+
+		offset += span_get_total_size(span_base_ptr);
+	}
+
+	return spans;
+}
+
+std::string span_to_str(const struct span_base *base)
+{
+	std::map<uint64_t, const std::string> span_type_names = {{SPAN_ENTRY, std::string("entry")},
+								 {SPAN_REGION, std::string("region")},
+								 {SPAN_EMPTY, std::string("empty")}};
+
+	return "type: " + span_type_names[span_get_type(base)] + ", data size: " + std::to_string(span_get_size(base));
+}
+
+std::ostream &operator<<(std::ostream &os, const struct span_base *base)
+{
+	return (os << span_to_str(base));
+}
+
+static std::ostream &show_spans(std::ostream &os, const std::vector<span_runtime> &spans,
+				const std::string &prefix = "")
+{
+	for (auto &s : spans) {
+		os << prefix << "├── offset: " << s.offset << " ," << span_to_str(s.ptr) << std::endl;
+		show_spans(os, s.sub_spans, prefix + "|   ");
+	}
+	return os;
+}
+
+std::ostream &operator<<(std::ostream &os, const std::vector<span_runtime> &spans)
+{
+	return show_spans(os, spans);
+}

--- a/tests/common/stream_span_helpers.hpp
+++ b/tests/common/stream_span_helpers.hpp
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2022, Intel Corporation */
+
+#ifndef LIBPMEMSTREAM_STREAM_SPAN_HELPERS_HPP
+#define LIBPMEMSTREAM_STREAM_SPAN_HELPERS_HPP
+
+#include <iostream>
+#include <vector>
+
+struct span_base;
+namespace pmem
+{
+struct stream;
+}
+
+struct span_runtime {
+	size_t offset;
+	const span_base *ptr;
+	std::vector<span_runtime> sub_spans;
+};
+
+std::vector<span_runtime> span_runtimes_from_stream(const pmem::stream &stream, size_t offset, size_t end_offset);
+std::string span_to_str(const struct span_base *base);
+std::ostream &operator<<(std::ostream &os, const struct span_base *base);
+std::ostream &operator<<(std::ostream &os, const std::vector<span_runtime> &spans);
+
+#endif /* LIBPMEMSTREAM_STREAM_SPAN_HELPERS_HPP */

--- a/tests/layout/iterate_all.cpp
+++ b/tests/layout/iterate_all.cpp
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2021-2022, Intel Corporation */
+
+/*
+ * iterate_validation.cpp -- verifies if randomly generated (inconsistent) spans are not
+ *                           treated by pmemstream iterators as valid entries.
+ */
+
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include <rapidcheck.h>
+
+#include "common/util.h"
+#include "libpmemstream_internal.h"
+#include "rapidcheck_helpers.hpp"
+#include "span.h"
+#include "stream_helpers.hpp"
+#include "stream_span_helpers.hpp"
+#include "unittest.hpp"
+
+int main(int argc, char *argv[])
+{
+	if (argc != 2) {
+		std::cout << "Usage: " << argv[0] << " file-path" << std::endl;
+		return -1;
+	}
+
+	struct test_config_type test_config;
+	test_config.filename = std::string(argv[1]);
+
+	return run_test(test_config, [&] {
+		return_check ret;
+
+		ret += rc::check(
+			"verify if stream does not treat inconsistent spans as valid entries",
+			[&](pmemstream_with_single_empty_region &&stream, const std::vector<std::string> &data) {
+				RC_PRE(data.size() > 0);
+				stream.helpers.append(stream.helpers.get_first_region(), data);
+
+				auto span_view = span_runtimes_from_stream(stream.sut, 0, UINT64_MAX);
+				UT_ASSERTeq(span_get_type(span_view[0].ptr), SPAN_REGION);
+				auto &region = span_view[0];
+				auto &entries = region.sub_spans;
+				auto expected_num_spans = data.size() + 1 /* one empty span. */;
+				UT_ASSERTeq(entries.size(), expected_num_spans);
+				for (size_t i = 0; i < data.size(); i++) {
+					auto data_ptr =
+						reinterpret_cast<const char *>(entries[i].ptr) + sizeof(span_entry);
+					UT_ASSERT(std::string(data_ptr, span_get_size(entries[i].ptr)) == data[i]);
+				}
+			});
+	});
+}


### PR DESCRIPTION
It allows to easily peek at the requested span. It also allows to print pmemstream
in a readable format. Combined with use of rapidcheck generators, pmemstream layout
will now be printed on each rc test failure (for tests which use those generators).

Example output from failing test:
```
58: -- Stderr:
58: Using configuration: seed=11041364771112123849
58: 
58: - verify if stream does not treat inconsistent spans as valid entries
58: Falsifiable after 1 tests and 1 shrink
58: 
58: std::tuple<pmemstream_with_single_empty_region, std::vector<std::string>>:
58: (filename: /dev/shm/iterate_all_0_none/testfile
58: block_size: 4096
58: size: 1048576
58: call_initialize_region_runtime: 1
58: call_initialize_region_runtime_after_reopen: 0
58: ├── offset: 0 ,type: region, data size: 1036224
58: |   ├── offset: 64 ,type: empty, data size: 1036216
58: ├── offset: 1036288 ,type: empty, data size: 0
58: , [""])
58: 
58: Exception thrown with message:
58: /opt/workspace/tests/layout/iterate_all.cpp:47 operator() - assertion failure: entries.size() (0x2) == expected_num_spans (0x1), errormsg: 

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemstream/139)
<!-- Reviewable:end -->
