### PR TITLE
tests: drop doubled declaration of 'c_ptr' helper

### DIFF
--- a/tests/common/stream_helpers.hpp
+++ b/tests/common/stream_helpers.hpp
@@ -65,11 +65,6 @@ struct stream {
 		c_stream.reset();
 	}
 
-	pmemstream *c_ptr()
-	{
-		return c_stream.get();
-	}
-
 	std::tuple<int, struct pmemstream_region_runtime *> region_runtime_initialize(struct pmemstream_region region)
 	{
 		struct pmemstream_region_runtime *runtime = nullptr;


### PR DESCRIPTION
git/GitHub failed to automatically merge these two same declarations (from 2 different PRs).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemstream/141)
<!-- Reviewable:end -->
