### PR TITLE
Move pmemstream_data_runtime to separate file

### DIFF
--- a/src/libpmemstream.c
+++ b/src/libpmemstream.c
@@ -120,7 +120,7 @@ int pmemstream_from_map(struct pmemstream **stream, size_t block_size, struct pm
 	s->usable_size = pmemstream_usable_size(s->stream_size, block_size);
 	s->block_size = block_size;
 
-	s->data.spans = (span_bytes *)(((uint8_t *)pmem2_map_get_address(map)) + spans_offset);
+	s->data.base = ((uint8_t *)pmem2_map_get_address(map)) + spans_offset;
 	s->data.memcpy = pmem2_get_memcpy_fn(map);
 	s->data.memset = pmem2_get_memset_fn(map);
 	s->data.persist = pmem2_get_persist_fn(map);

--- a/src/pmemstream_runtime.h
+++ b/src/pmemstream_runtime.h
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2022, Intel Corporation */
+
+/* Internal Header */
+
+#ifndef LIBPMEMSTREAM_RUNTIME_H
+#define LIBPMEMSTREAM_RUNTIME_H
+
+#include <stdint.h>
+
+#include <libpmem2.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct pmemstream_runtime {
+	void *base;
+
+	pmem2_memcpy_fn memcpy;
+	pmem2_memset_fn memset;
+	pmem2_flush_fn flush;
+	pmem2_drain_fn drain;
+	pmem2_persist_fn persist;
+};
+
+static inline const uint8_t *pmemstream_offset_to_ptr(const struct pmemstream_runtime *data, uint64_t offset)
+{
+	return (const uint8_t *)data->base + offset;
+}
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+#endif /* LIBPMEMSTREAM_RUNTIME_H */

--- a/tests/common/stream_span_helpers.cpp
+++ b/tests/common/stream_span_helpers.cpp
@@ -10,7 +10,7 @@
 std::vector<span_runtime> span_runtimes_from_stream(const pmem::stream &stream, size_t offset, size_t end_offset)
 {
 	std::vector<span_runtime> spans;
-	auto span_bytes_ptr = reinterpret_cast<const char *>(stream.c_ptr()->data.spans);
+	auto span_bytes_ptr = reinterpret_cast<const char *>(stream.c_ptr()->data.base);
 	end_offset = std::min(end_offset, stream.c_ptr()->usable_size);
 
 	while (offset < end_offset) {

--- a/tests/unittest/singly_linked_list.cpp
+++ b/tests/unittest/singly_linked_list.cpp
@@ -63,8 +63,8 @@ int main(int argc, char *argv[])
 		singly_linked_list list;
 		SLIST_INIT(&list);
 
-		struct pmemstream_data_runtime runtime {
-			.spans = (uint64_t *)data.data(), .memcpy = &memcpy_mock, .memset = &memset_mock,
+		struct pmemstream_runtime runtime {
+			.base = (void *)data.data(), .memcpy = &memcpy_mock, .memset = &memset_mock,
 			.flush = &flush_mock, .drain = &drain_mock, .persist = &persist_mock
 		};
 
@@ -91,8 +91,8 @@ int main(int argc, char *argv[])
 
 		singly_linked_list list;
 		SLIST_INIT(&list);
-		struct pmemstream_data_runtime runtime {
-			.spans = (uint64_t *)data.data(), .memcpy = &memcpy_mock, .memset = &memset_mock,
+		struct pmemstream_runtime runtime {
+			.base = (void *)data.data(), .memcpy = &memcpy_mock, .memset = &memset_mock,
 			.flush = &flush_mock, .drain = &drain_mock, .persist = &persist_mock
 		};
 
@@ -119,8 +119,8 @@ int main(int argc, char *argv[])
 
 		singly_linked_list list;
 		SLIST_INIT(&list);
-		struct pmemstream_data_runtime runtime {
-			.spans = (uint64_t *)data.data(), .memcpy = &memcpy_mock, .memset = &memset_mock,
+		struct pmemstream_runtime runtime {
+			.base = (void *)data.data(), .memcpy = &memcpy_mock, .memset = &memset_mock,
 			.flush = &flush_mock, .drain = &drain_mock, .persist = &persist_mock
 		};
 
@@ -159,8 +159,8 @@ int main(int argc, char *argv[])
 
 		singly_linked_list list;
 		SLIST_INIT(&list);
-		struct pmemstream_data_runtime runtime {
-			.spans = (uint64_t *)data.data(), .memcpy = &memcpy_mock, .memset = &memset_mock,
+		struct pmemstream_runtime runtime {
+			.base = (void *)data.data(), .memcpy = &memcpy_mock, .memset = &memset_mock,
 			.flush = &flush_mock, .drain = &drain_mock, .persist = &persist_mock
 		};
 


### PR DESCRIPTION
And make it independent from pmemstream types. This will allow
to use pmemstream_runtime without including libpmemstream_internal.h
which has dependencies on most internal headers.