### PR TITLE
Fix TESTS_USE_FORCED_PMEM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ option(USE_LIBUNWIND "use libunwind for more reliable stack traces from tests (i
 option(USE_ASAN "enable AddressSanitizer checks" OFF)
 option(USE_UBSAN "enable UndefinedBehaviorSanitizer checks" OFF)
 
-option(TESTS_USE_FORCED_PMEM "run tests with PMEM_IS_PMEM_FORCE=1 - it speeds up tests execution on emulated pmem" OFF)
+option(TESTS_USE_FORCED_PMEM "run tests with PMEM2_FORCE_GRANULARITY=CACHE_LINE - it speeds up tests execution on emulated pmem" OFF)
 option(TESTS_USE_VALGRIND "enable tests with valgrind (fail build if Valgrind not found)" ON)
 option(TESTS_PMREORDER "enable tests with pmreorder (if pmreorder found; it requires PMDK ver. >= 1.9)" OFF)
 option(TESTS_LONG "enable long running tests" OFF)

--- a/tests/cmake/exec_functions.cmake
+++ b/tests/cmake/exec_functions.cmake
@@ -105,10 +105,6 @@ function(execute_common expect_success output_file name)
 	endif()
 
 	if(${TRACER} STREQUAL pmemcheck)
-		if(TESTS_USE_FORCED_PMEM)
-			# pmemcheck runs really slow with pmem, disable it
-			unset(ENV{PMEM2_FORCE_GRANULARITY})
-		endif()
 		set(TRACE valgrind --error-exitcode=99 --tool=pmemcheck)
 	elseif(${TRACER} STREQUAL memcheck)
 		set(TRACE valgrind --error-exitcode=99 --tool=memcheck --leak-check=full --max-threads=3000

--- a/tests/cmake/exec_functions.cmake
+++ b/tests/cmake/exec_functions.cmake
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2018-2021, Intel Corporation
+# Copyright 2018-2022, Intel Corporation
 
 #
 # exec_functions.cmake - helper variables and functions for
@@ -101,13 +101,13 @@ endfunction()
 #		perhaps it'd be enough to move GDB checks and setup into sep. function
 function(execute_common expect_success output_file name)
 	if(TESTS_USE_FORCED_PMEM)
-		set(ENV{PMEM_IS_PMEM_FORCE} 1)
+		set(ENV{PMEM2_FORCE_GRANULARITY} CACHE_LINE)
 	endif()
 
 	if(${TRACER} STREQUAL pmemcheck)
 		if(TESTS_USE_FORCED_PMEM)
 			# pmemcheck runs really slow with pmem, disable it
-			set(ENV{PMEM_IS_PMEM_FORCE} 0)
+			unset(ENV{PMEM2_FORCE_GRANULARITY})
 		endif()
 		set(TRACE valgrind --error-exitcode=99 --tool=pmemcheck)
 	elseif(${TRACER} STREQUAL memcheck)
@@ -210,7 +210,7 @@ function(execute_common expect_success output_file name)
 	endif()
 
 	if(TESTS_USE_FORCED_PMEM)
-		unset(ENV{PMEM_IS_PMEM_FORCE})
+		unset(ENV{PMEM2_FORCE_GRANULARITY})
 	endif()
 endfunction()
 

--- a/utils/docker/prepare-for-build.sh
+++ b/utils/docker/prepare-for-build.sh
@@ -81,7 +81,11 @@ function run_binary_standalone() {
 
 	pushd ${STANDALONE_BUILD_DIR}
 
-	PMEM_IS_PMEM_FORCE=${TESTS_USE_FORCED_PMEM} ./${binary_name} ${optional_args}
+	if [[ $TESTS_USE_FORCED_PMEM ]]; then
+		PMEM2_FORCE_GRANULARITY=CACHE_LINE ./${binary_name} ${optional_args}
+	else
+		./${binary_name} ${optional_args}
+	fi
 
 	# exit on error
 	if [[ $? != 0 ]]; then


### PR DESCRIPTION
Use PMEM2_FORCE_GRANULARITY variable instead of PMEM_IS_PMEM_FORCE
which was ignored (it only worked for pmem 1.0)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemstream/155)
<!-- Reviewable:end -->
