### PR TITLE
Introduce CACHELINE_SIZE macro and use alignas instead of padding

### DIFF
--- a/src/common/util.h
+++ b/src/common/util.h
@@ -15,6 +15,9 @@
 
 #define MEMBER_SIZE(type, member) sizeof(((struct type *)NULL)->member)
 
+/* XXX: add support for different architectures. */
+#define CACHELINE_SIZE (64ULL)
+
 static inline unsigned char util_popcount64(uint64_t value)
 {
 	return (unsigned char)__builtin_popcountll(value);

--- a/src/libpmemstream.c
+++ b/src/libpmemstream.c
@@ -66,8 +66,7 @@ static int pmemstream_validate_sizes(size_t block_size, struct pmem2_map *map)
 		return -1;
 	}
 
-	/* XXX: change 64 to CACHELINE_SIZE */
-	if (block_size % 64 != 0) {
+	if (block_size % CACHELINE_SIZE != 0) {
 		return -1;
 	}
 
@@ -193,8 +192,7 @@ int pmemstream_region_allocate(struct pmemstream *stream, size_t size, struct pm
 
 #ifndef NDEBUG
 	struct span_region *stored_span_region = (struct span_region *)span_base;
-	/* XXX: use CACHELINE_SIZE instead of 64 */
-	assert(((uintptr_t)stored_span_region->data) % 64 == 0);
+	assert(((uintptr_t)stored_span_region->data) % CACHELINE_SIZE == 0);
 #endif
 
 	return 0;

--- a/src/mpmc_queue.c
+++ b/src/mpmc_queue.c
@@ -4,30 +4,36 @@
 #include "mpmc_queue.h"
 
 #include <assert.h>
+#include <stdalign.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>
 
-struct mpmc_queue_producer {
-	uint64_t granted_offset;
+#include "common/util.h"
 
-	/* avoid false sharing by padding the variable */
-	// XXX: calculate 7 from CACHELINE_SIZE
-	uint64_t padding[7];
+struct mpmc_queue_producer {
+	/* avoid false sharing by aligning to cacheline */
+	alignas(CACHELINE_SIZE) uint64_t granted_offset;
 };
+
+static_assert(sizeof(struct mpmc_queue_producer) == CACHELINE_SIZE,
+	      "struct mpmc_queue_producer mut be cacheline aligned");
 
 struct mpmc_queue {
 	uint64_t num_producers;
 	size_t size;
-	uint64_t produce_offset;
-	uint64_t padding_produce_offset[5];
 
-	uint64_t consume_offset;
-	uint64_t padding_consume_offset[7];
+	alignas(CACHELINE_SIZE) uint64_t produce_offset;
+	alignas(CACHELINE_SIZE) uint64_t consume_offset;
 
 	struct mpmc_queue_producer producers[];
 };
+
+static_assert(sizeof(struct mpmc_queue) == 3 * CACHELINE_SIZE, "size of struct mpmc_queue is wrong");
+static_assert(offsetof(struct mpmc_queue, consume_offset) - offsetof(struct mpmc_queue, produce_offset) >=
+		      CACHELINE_SIZE,
+	      "consume offset and produce offset should be in different cachelines");
 
 /* XXX: add support for dynamic producer registration? */
 struct mpmc_queue *mpmc_queue_new(size_t num_producers, size_t size)
@@ -36,7 +42,8 @@ struct mpmc_queue *mpmc_queue_new(size_t num_producers, size_t size)
 		return NULL;
 	}
 
-	struct mpmc_queue *queue = malloc(sizeof(*queue) + num_producers * sizeof(struct mpmc_queue_producer));
+	struct mpmc_queue *queue = aligned_alloc(alignof(struct mpmc_queue),
+						 sizeof(*queue) + num_producers * sizeof(struct mpmc_queue_producer));
 	if (!queue) {
 		return NULL;
 	}

--- a/src/span.h
+++ b/src/span.h
@@ -8,8 +8,12 @@
 
 #include "libpmemstream.h"
 
+#include <assert.h>
+#include <stdalign.h>
 #include <stdint.h>
 #include <stdlib.h>
+
+#include "common/util.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,10 +38,12 @@ struct span_base {
 };
 
 struct span_region {
-	struct span_base span_base;
-	uint64_t padding[7]; /* XXX: CACHELINE_SIZE - sizeof(struct span_base) */
-	uint64_t data[];
+	alignas(CACHELINE_SIZE) struct span_base span_base;
+	alignas(CACHELINE_SIZE) uint64_t data[];
 };
+
+static_assert(sizeof(struct span_region) == CACHELINE_SIZE,
+	      "size of struct span_region must be equal to CACHELINE_SIZE");
 
 struct span_entry {
 	struct span_base span_base;

--- a/tests/unittest/create.cpp
+++ b/tests/unittest/create.cpp
@@ -18,8 +18,7 @@ namespace
 {
 std::pair<size_t, size_t> generate_region_size_and_block_size(size_t stream_size)
 {
-	/* XXX: use CACHELINE_SIZE instead of 64 */
-	const auto minimum_block_size = 64;
+	const auto minimum_block_size = CACHELINE_SIZE;
 	const auto max_block_and_region_size = stream_size;
 
 	const auto block_size_pow =
@@ -142,8 +141,7 @@ int main(int argc, char *argv[])
 			[&]() {
 				auto block_size = *rc::gen::inRange<std::size_t>(
 					1ULL, get_test_config().stream_size / 2UL - STREAM_METADATA_SIZE);
-				/* XXX: use CACHELINE_SIZE instead of 64 */
-				RC_PRE(block_size % 64 != 0 || !IS_POW2(block_size));
+				RC_PRE(block_size % CACHELINE_SIZE != 0 || !IS_POW2(block_size));
 
 				try {
 					make_pmemstream(get_test_config().filename, block_size,


### PR DESCRIPTION
All features used in this patch (alignas, offsetof, static_assert)
are part of C11 standard

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemstream/158)
<!-- Reviewable:end -->
