### PR TITLE
pmreorder region allocator test

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -164,8 +164,11 @@ endif()
 
 if(TESTS_PMREORDER)
 	build_test(singly_linked_list_pmreorder integrity/singly_linked_list_pmreorder.cpp)
-	add_test_generic(NAME singly_linked_list_pmreorder SCRIPT integrity/singly_linked_list_pmreorder.cmake TRACERS none)
-	add_test_generic(NAME singly_linked_list_pmreorder CASE negative SCRIPT integrity/singly_linked_list_pmreorder_negative.cmake TRACERS none)
+	add_test_generic(NAME singly_linked_list_pmreorder SCRIPT integrity/default_create_fill_check.cmake TRACERS none)
+	add_test_generic(NAME singly_linked_list_pmreorder CASE negative SCRIPT integrity/default_create_fill_check_negative.cmake TRACERS none)
+
+	build_test(multi_region_pmreorder integrity/multi_region_pmreorder.cpp)
+	add_test_generic(NAME multi_region_pmreorder SCRIPT integrity/default_create_fill_check.cmake TRACERS none)
 endif()
 
 if(GDB AND DEBUG_BUILD)

--- a/tests/common/random_helpers.hpp
+++ b/tests/common/random_helpers.hpp
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2022, Intel Corporation */
+
+#ifndef LIBPMEMSTREAM_RANDOM_HELPERS_HPP
+#define LIBPMEMSTREAM_RANDOM_HELPERS_HPP
+
+#include <iostream>
+#include <random>
+#include <vector>
+
+#include "unittest.hpp"
+
+static std::mt19937_64 rnd_generator;
+
+static inline void init_random()
+{
+	uint64_t seed;
+	const char *seed_env = std::getenv("TEST_SEED");
+	if (seed_env == NULL) {
+		std::random_device rd;
+		seed = rd();
+		std::cout << "To reproduce set env variable TEST_SEED=" << seed << std::endl;
+	} else {
+		seed = std::stoull(seed_env);
+		std::cout << "Running with TEST_SEED=" << seed << std::endl;
+	}
+	rnd_generator = std::mt19937_64(seed);
+}
+
+/* generates sequence of n commands out of 'commands' list */
+template <typename T>
+static inline std::vector<T> generate_commands(size_t n, std::vector<T> commands)
+{
+	std::vector<T> out;
+	for (size_t i = 0; i < n; i++) {
+		/* puts back to 'out' a single element from 'commands' list */
+		const size_t samples_number = 1;
+		std::sample(commands.begin(), commands.end(), std::back_inserter(out), samples_number, rnd_generator);
+	}
+	return out;
+}
+
+#endif /* LIBPMEMSTREAM_RANDOM_HELPERS_HPP */

--- a/tests/common/unittest.hpp
+++ b/tests/common/unittest.hpp
@@ -10,6 +10,7 @@
 #include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
+#include <filesystem>
 #include <functional>
 #include <iostream>
 #include <memory>
@@ -136,6 +137,14 @@ auto make_instance_ctor(Ctor &&ctor, Dtor &&dtor)
 		}
 		return ptr;
 	};
+}
+
+static inline std::filesystem::path copy_file(std::string path)
+{
+	std::filesystem::path copy_path = path;
+	copy_path += ".cpy";
+	std::filesystem::copy_file(path, copy_path, std::filesystem::copy_options::overwrite_existing);
+	return copy_path;
 }
 
 #endif /* LIBPMEMSTREAM_UNITTEST_HPP */

--- a/tests/integrity/default_create_fill_check.cmake
+++ b/tests/integrity/default_create_fill_check.cmake
@@ -12,6 +12,6 @@ execute(${EXECUTABLE} check ${DIR}/pretest_testfile)
 
 execute(${EXECUTABLE} create ${DIR}/testfile)
 pmreorder_create_store_log(${DIR}/testfile ${EXECUTABLE} fill ${DIR}/testfile)
-pmreorder_execute(${EXPECT_SUCCESS} ReorderAccumulative ${SRC_DIR}/pmreorder.conf ${EXECUTABLE} check)
+pmreorder_execute(${EXPECT_SUCCESS} ReorderAccumulative ${SRC_DIR}/integrity/pmreorder.conf ${EXECUTABLE} check)
 
 finish()

--- a/tests/integrity/default_create_fill_check_negative.cmake
+++ b/tests/integrity/default_create_fill_check_negative.cmake
@@ -8,10 +8,10 @@ setup()
 
 execute(${EXECUTABLE} create ${DIR}/pretest_testfile)
 execute(${EXECUTABLE} fill ${DIR}/pretest_testfile)
-execute(${EXECUTABLE} check ${DIR}/pretest_testfile)
+execute(${EXECUTABLE} check_no_recovery ${DIR}/pretest_testfile)
 
 execute(${EXECUTABLE} create ${DIR}/testfile)
 pmreorder_create_store_log(${DIR}/testfile ${EXECUTABLE} fill ${DIR}/testfile)
-pmreorder_execute(${EXPECT_FAILURE} ReorderAccumulative ${SRC_DIR}/pmreorder.conf ${EXECUTABLE} check_without_recovery)
+pmreorder_execute(${EXPECT_FAILURE} ReorderAccumulative ${SRC_DIR}/integrity/pmreorder.conf ${EXECUTABLE} check_no_recovery)
 
 finish()

--- a/tests/integrity/multi_region_pmreorder.cpp
+++ b/tests/integrity/multi_region_pmreorder.cpp
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2022, Intel Corporation */
+
+#include "libpmemstream_internal.h"
+#include "random_helpers.hpp"
+#include "stream_helpers.hpp"
+#include "unittest.hpp"
+
+#include <filesystem>
+#include <iostream>
+
+#define TEST_COMMANDS_COUNT (50UL)
+
+void fill(test_config_type test_config, size_t cmd_count = TEST_COMMANDS_COUNT)
+{
+	bool no_truncate = false;
+	auto stream =
+		make_pmemstream(test_config.filename, test_config.block_size, test_config.stream_size, no_truncate);
+
+	const size_t region_size = TEST_DEFAULT_BLOCK_SIZE;
+	std::vector<struct pmemstream_region> regions;
+
+	for (size_t i = 0; i < cmd_count; i++) {
+		auto command = rnd_generator() % 2; /* allocate & free */
+
+		if (command == 0) {
+			struct pmemstream_region region;
+			int ret = pmemstream_region_allocate(stream.get(), region_size, &region);
+			UT_ASSERTeq(ret, 0);
+			regions.push_back(region);
+		} else if (command == 1) {
+			/* free (only if preceeded by any, non-freed allocation) */
+			// XXX: get rid of the "true" statement; _free is not working properly
+			if (true || regions.size() == 0) {
+				continue;
+			}
+
+			size_t region_pos = rnd_generator() % regions.size();
+			auto region = regions[region_pos];
+			int ret = pmemstream_region_free(stream.get(), region);
+			UT_ASSERTeq(ret, 0);
+			regions.erase(regions.begin() + static_cast<long>(region_pos));
+		}
+	}
+}
+
+void check_consistency(test_config_type test_config)
+{
+	auto copy_path = copy_file(test_config.filename);
+	bool no_truncate = false;
+	bool no_init = false;
+
+	struct pmemstream_test_base s(copy_path, test_config.block_size, test_config.stream_size, no_truncate, no_init);
+
+	auto riter = s.sut.region_iterator();
+	int region_counter = -1;
+	int ret = 0;
+	do {
+		++region_counter;
+		struct pmemstream_region region;
+		ret = pmemstream_region_iterator_next(riter.get(), &region);
+	} while (ret == 0);
+
+	// XXX: investigate consistency assurance
+	// struct pmemstream_region region;
+	// ret = pmemstream_region_allocate(s.sut.c_ptr(), TEST_DEFAULT_BLOCK_SIZE, &region);
+	// UT_ASSERTeq(ret, 0);
+	// UT_ASSERTeq(static_cast<size_t>(region_counter + 1), s.helpers.count_regions());
+
+	// XXX: uncomment when region_free will work properly
+	// ret = pmemstream_region_free(s.sut.c_ptr(), region);
+	// UT_ASSERTeq(ret, 0);
+	// UT_ASSERTeq(static_cast<size_t>(region_counter), s.helpers.count_regions());
+}
+
+int main(int argc, char *argv[])
+{
+	if (argc != 3) {
+		std::cout << "Usage: " << argv[0] << "<create|fill|check> file-path" << std::endl;
+		return -1;
+	}
+
+	struct test_config_type test_config;
+	std::string mode = argv[1];
+	test_config.filename = argv[2];
+	/* requested region_size in this test is of "block_size", but it's actually double that, because of aligning */
+	test_config.stream_size = STREAM_METADATA_SIZE + 2 * TEST_DEFAULT_BLOCK_SIZE * (TEST_COMMANDS_COUNT + 1);
+
+	return run_test(test_config, [&] {
+		if (mode == "create") {
+			bool truncate = true;
+			bool do_init = true;
+			struct pmemstream_test_base stream(test_config.filename, test_config.block_size,
+							   test_config.stream_size, truncate, do_init);
+
+		} else if (mode == "fill") {
+			init_random();
+			fill(test_config);
+
+		} else if (mode == "check") {
+			check_consistency(test_config);
+
+		} else {
+			UT_FATAL("Wrong mode given!\nUsage: %s <create|fill|check> file-path", argv[0]);
+		}
+	});
+}

--- a/tests/integrity/pmreorder.conf
+++ b/tests/integrity/pmreorder.conf
@@ -1,2 +1,3 @@
 {
+    "libpmem2" : "NoReorderNoCheck"
 }

--- a/tests/integrity/singly_linked_list_pmreorder.cpp
+++ b/tests/integrity/singly_linked_list_pmreorder.cpp
@@ -138,7 +138,7 @@ void check_consistency(test_config_type test_config, bool with_recovery = true)
 int main(int argc, char *argv[])
 {
 	if (argc != 3)
-		UT_FATAL("usage: %s <create|fill|check|check_without_recovery> file-name", argv[0]);
+		UT_FATAL("usage: %s <create|fill|check|check_no_recovery> file-path", argv[0]);
 
 	struct test_config_type test_config;
 	std::string mode = argv[1];
@@ -152,9 +152,12 @@ int main(int argc, char *argv[])
 			fill(test_config);
 		} else if (mode == "check") {
 			check_consistency(test_config);
-		} else if (mode == "check_without_recovery") {
+		} else if (mode == "check_no_recovery") {
 			constexpr bool with_recovery = false;
 			check_consistency(test_config, with_recovery);
+		} else {
+			UT_FATAL("Wrong mode given!\nUsage: %s <create|fill|check|check_no_recovery> file-path",
+				 argv[0]);
 		}
 	});
 }

--- a/tests/integrity/singly_linked_list_pmreorder.cpp
+++ b/tests/integrity/singly_linked_list_pmreorder.cpp
@@ -8,7 +8,6 @@
 
 #include <algorithm>
 #include <cstdlib>
-#include <filesystem>
 #include <functional>
 #include <iostream>
 #include <vector>
@@ -118,17 +117,9 @@ void fill(test_config_type test_config)
 	}
 }
 
-std::filesystem::path make_working_copy(std::filesystem::path path)
-{
-	auto copy_path = path;
-	copy_path += ".cpy";
-	std::filesystem::copy_file(path, copy_path, std::filesystem::copy_options::overwrite_existing);
-	return copy_path;
-}
-
 void check_consistency(test_config_type test_config, bool with_recovery = true)
 {
-	auto copy_path = make_working_copy(test_config.filename);
+	auto copy_path = copy_file(test_config.filename);
 	constexpr bool truncate = false;
 	auto map = make_pmem2_map(copy_path.c_str(), test_config.stream_size, truncate);
 	auto runtime = get_runtime(map.get());


### PR DESCRIPTION
- [x] add commands generation

for this test to work I had to omit stores within "libpmem2" marker - these lots of stores appear due to memsetting region (with 0's) while allocating that region.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemstream/164)
<!-- Reviewable:end -->
