### PR TITLE
Fix minor tests' issues

### DIFF
--- a/tests/common/stream_span_helpers.cpp
+++ b/tests/common/stream_span_helpers.cpp
@@ -51,7 +51,7 @@ static std::ostream &show_spans(std::ostream &os, const std::vector<span_runtime
 				const std::string &prefix = "")
 {
 	for (auto &s : spans) {
-		os << prefix << "├── offset: " << s.offset << " ," << span_to_str(s.ptr) << std::endl;
+		os << prefix << "├── offset: " << s.offset << ", " << span_to_str(s.ptr) << std::endl;
 		show_spans(os, s.sub_spans, prefix + "|   ");
 	}
 	return os;

--- a/tests/unittest/mpmc_queue.cpp
+++ b/tests/unittest/mpmc_queue.cpp
@@ -8,7 +8,6 @@
 #include <rapidcheck.h>
 #include <rapidcheck/state.h>
 
-#include "env_setter.hpp"
 #include "mpmc_queue.h"
 #include "thread_helpers.hpp"
 #include "unittest.hpp"

--- a/tests/unittest/publish_append_async.cpp
+++ b/tests/unittest/publish_append_async.cpp
@@ -19,7 +19,8 @@
 int main(int argc, char *argv[])
 {
 	if (argc != 2) {
-		UT_FATAL("usage: %s file-path", argv[0]);
+		std::cout << "Usage: " << argv[0] << " file-path" << std::endl;
+		return -1;
 	}
 
 	struct test_config_type test_config;

--- a/tests/unittest/reserve_publish.cpp
+++ b/tests/unittest/reserve_publish.cpp
@@ -20,7 +20,8 @@
 int main(int argc, char *argv[])
 {
 	if (argc != 2) {
-		UT_FATAL("usage: %s file-path", argv[0]);
+		std::cout << "Usage: " << argv[0] << " file-path" << std::endl;
+		return -1;
 	}
 
 	struct test_config_type test_config;


### PR DESCRIPTION
- do not use `UT_FATAL` in tests' main function (found by Coverity),
- get rid of retudndant "env_setter.h" include in one of the tests,
- fix styling issue in debug printing stream in our helpers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemstream/165)
<!-- Reviewable:end -->
