### PR TITLE
refactor region iterator

### DIFF
--- a/examples/01_basic_iterate/main.c
+++ b/examples/01_basic_iterate/main.c
@@ -44,10 +44,13 @@ int main(int argc, char *argv[])
 		return ret;
 	}
 
-	struct pmemstream_region region;
-
 	/* Iterate over all regions. */
-	while (pmemstream_region_iterator_next(riter, &region) == 0) {
+	do {
+		struct pmemstream_region region;
+		if (pmemstream_region_iterator_get(riter, &region) != 0) {
+			break;
+		}
+
 		struct pmemstream_entry entry;
 		struct pmemstream_entry_iterator *eiter;
 		ret = pmemstream_entry_iterator_new(&eiter, stream, region);
@@ -73,7 +76,7 @@ int main(int argc, char *argv[])
 			fprintf(stderr, "pmemstream_append failed\n");
 			return ret;
 		}
-	}
+	} while (pmemstream_region_iterator_next(riter) == 0);
 
 	pmemstream_region_iterator_delete(&riter);
 

--- a/examples/02_visual_iterator/main.cpp
+++ b/examples/02_visual_iterator/main.cpp
@@ -34,7 +34,6 @@ void print_help(const char *exec_filename)
 int main(int argc, char *argv[])
 {
 	bool values_as_text = false;
-	struct pmemstream_region region;
 
 	if (argc < 2 || argc > 3) {
 		print_help(argv[0]);
@@ -71,7 +70,12 @@ int main(int argc, char *argv[])
 
 	/* Iterate over all regions. */
 	size_t region_id = 0;
-	while (pmemstream_region_iterator_next(riter, &region) == 0) {
+	do {
+		struct pmemstream_region region;
+		if (pmemstream_region_iterator_get(riter, &region) != 0) {
+			break;
+		}
+
 		struct pmemstream_entry entry;
 		struct pmemstream_entry_iterator *eiter;
 		ret = pmemstream_entry_iterator_new(&eiter, stream, region);
@@ -101,7 +105,7 @@ int main(int argc, char *argv[])
 			printf("\n");
 		}
 		pmemstream_entry_iterator_delete(&eiter);
-	}
+	} while (pmemstream_region_iterator_next(riter) == 0);
 
 	pmemstream_region_iterator_delete(&riter);
 	pmemstream_delete(&stream);

--- a/examples/04_basic_async/main.cpp
+++ b/examples/04_basic_async/main.cpp
@@ -50,7 +50,11 @@ int main(int argc, char *argv[])
 
 	int i = 0;
 	for (; i < EXAMPLE_ASYNC_COUNT; ++i) {
-		ret = pmemstream_region_iterator_next(riter, &regions[i]);
+		ret = pmemstream_region_iterator_get(riter, &regions[i]);
+		if (ret != 0) {
+			break;
+		}
+		ret = pmemstream_region_iterator_next(riter);
 		if (ret != 0) {
 			break;
 		}

--- a/src/include/libpmemstream.h
+++ b/src/include/libpmemstream.h
@@ -151,7 +151,9 @@ size_t pmemstream_entry_length(struct pmemstream *stream, struct pmemstream_entr
 
 int pmemstream_region_iterator_new(struct pmemstream_region_iterator **iterator, struct pmemstream *stream);
 
-int pmemstream_region_iterator_next(struct pmemstream_region_iterator *iterator, struct pmemstream_region *region);
+int pmemstream_region_iterator_next(struct pmemstream_region_iterator *iterator);
+
+int pmemstream_region_iterator_get(struct pmemstream_region_iterator *iterator, struct pmemstream_region *region);
 
 void pmemstream_region_iterator_delete(struct pmemstream_region_iterator **iterator);
 

--- a/src/iterator.c
+++ b/src/iterator.c
@@ -30,7 +30,29 @@ int pmemstream_region_iterator_new(struct pmemstream_region_iterator **iterator,
 	return 0;
 }
 
-int pmemstream_region_iterator_next(struct pmemstream_region_iterator *it, struct pmemstream_region *region)
+int pmemstream_region_iterator_next(struct pmemstream_region_iterator *it)
+{
+	if (!it) {
+		return -1;
+	}
+
+	if (it->region.offset == SLIST_INVALID_OFFSET) {
+		return -1;
+	}
+
+	struct pmemstream_region next_region;
+	next_region.offset = SLIST_NEXT(struct span_region, &it->stream->data, it->region.offset,
+					allocator_entry_metadata.next_allocated);
+
+	if (next_region.offset == SLIST_INVALID_OFFSET) {
+		return -1;
+	}
+
+	it->region.offset = next_region.offset;
+	return 0;
+}
+
+int pmemstream_region_iterator_get(struct pmemstream_region_iterator *it, struct pmemstream_region *region)
 {
 	if (!it) {
 		return -1;
@@ -41,11 +63,6 @@ int pmemstream_region_iterator_next(struct pmemstream_region_iterator *it, struc
 	}
 
 	*region = it->region;
-
-	/* XXX: hide this in allocator? */
-	/* XXX: lock */
-	it->region.offset = SLIST_NEXT(struct span_region, &it->stream->data, it->region.offset,
-				       allocator_entry_metadata.next_allocated);
 	return 0;
 }
 

--- a/src/libpmemstream.map
+++ b/src/libpmemstream.map
@@ -16,6 +16,7 @@ LIBPMEMSTREAM_1.0 {
 		pmemstream_region_iterator_delete;
 		pmemstream_region_iterator_new;
 		pmemstream_region_iterator_next;
+		pmemstream_region_iterator_get;
 		pmemstream_region_size;
 		pmemstream_append;
 		pmemstream_publish;

--- a/tests/api_c/region_iterator.c
+++ b/tests/api_c/region_iterator.c
@@ -25,10 +25,10 @@ void valid_input_test(char *path)
 	UT_ASSERTeq(ret, 0);
 	UT_ASSERTne(riter, NULL);
 
-	ret = pmemstream_region_iterator_next(riter, &region);
+	ret = pmemstream_region_iterator_get(riter, &region);
 	UT_ASSERTeq(ret, 0);
 
-	ret = pmemstream_region_iterator_next(riter, &region);
+	ret = pmemstream_region_iterator_next(riter);
 	UT_ASSERTeq(ret, -1);
 
 	pmemstream_region_iterator_delete(&riter);
@@ -50,28 +50,28 @@ void null_iterator_test(char *path)
 	ret = pmemstream_region_iterator_new(NULL, env.stream);
 	UT_ASSERTeq(ret, -1);
 
-	ret = pmemstream_region_iterator_next(NULL, &region);
+	ret = pmemstream_region_iterator_get(NULL, &region);
 	UT_ASSERTeq(ret, -1);
 
 	pmemstream_region_free(env.stream, region);
 	pmemstream_test_teardown(env);
 }
 
-void invalid_region_test(char *path)
+void no_allocated_regions_test(char *path)
 {
 	pmemstream_test_env env = pmemstream_test_make_default(path);
 
-	const uint64_t invalid_offset = ALIGN_DOWN(UINT64_MAX, sizeof(span_bytes));
+	const uint64_t arbitrary_offset = 42;
 	struct pmemstream_region_iterator *riter = NULL;
-	struct pmemstream_region invalid_region = {.offset = invalid_offset};
+	struct pmemstream_region region = {.offset = arbitrary_offset};
 
 	int ret = pmemstream_region_iterator_new(&riter, env.stream);
 	UT_ASSERTeq(ret, 0);
 	UT_ASSERTne(riter, NULL);
 
-	ret = pmemstream_region_iterator_next(riter, &invalid_region);
+	ret = pmemstream_region_iterator_get(riter, &region);
 	UT_ASSERTeq(ret, -1);
-	UT_ASSERTeq(invalid_region.offset, invalid_offset);
+	UT_ASSERTeq(region.offset, arbitrary_offset);
 
 	pmemstream_region_iterator_delete(&riter);
 	pmemstream_test_teardown(env);
@@ -101,7 +101,7 @@ int main(int argc, char *argv[])
 
 	valid_input_test(path);
 	null_iterator_test(path);
-	invalid_region_test(path);
+	no_allocated_regions_test(path);
 	null_stream_test();
 
 	return 0;

--- a/tests/common/stream_helpers.hpp
+++ b/tests/common/stream_helpers.hpp
@@ -331,13 +331,15 @@ struct pmemstream_helpers_type {
 	struct pmemstream_region get_region(size_t n)
 	{
 		auto riter = stream.region_iterator();
-		size_t counter = 0;
 
 		struct pmemstream_region region;
-		do {
-			int ret = pmemstream_region_iterator_next(riter.get(), &region);
+		for (size_t i = 0; i < n; i++) {
+			int ret = pmemstream_region_iterator_next(riter.get());
 			UT_ASSERTeq(ret, 0);
-		} while (counter++ < n);
+		}
+
+		int ret = pmemstream_region_iterator_get(riter.get(), &region);
+		UT_ASSERTeq(ret, 0);
 
 		return region;
 	}
@@ -353,14 +355,13 @@ struct pmemstream_helpers_type {
 		auto riter = stream.region_iterator();
 
 		std::vector<struct pmemstream_region> regions;
-		while (true) {
+		do {
 			struct pmemstream_region region;
-			int ret = pmemstream_region_iterator_next(riter.get(), &region);
-			if (ret != 0)
+			if (pmemstream_region_iterator_get(riter.get(), &region) != 0) {
 				break;
-
+			}
 			regions.push_back(region);
-		}
+		} while (pmemstream_region_iterator_next(riter.get()) == 0);
 
 		return regions;
 	}
@@ -401,10 +402,12 @@ struct pmemstream_helpers_type {
 	size_t count_regions()
 	{
 		auto riter = stream.region_iterator();
-
-		size_t region_counter = 0;
 		struct pmemstream_region region;
-		while (pmemstream_region_iterator_next(riter.get(), &region) != -1) {
+		if (pmemstream_region_iterator_get(riter.get(), &region) != 0) {
+			return 0;
+		}
+		size_t region_counter = 1;
+		while (pmemstream_region_iterator_next(riter.get()) != -1) {
 			++region_counter;
 		}
 		return region_counter;
@@ -418,9 +421,9 @@ struct pmemstream_helpers_type {
 
 		struct pmemstream_region region;
 		do {
-			UT_ASSERTeq(pmemstream_region_iterator_next(riter.get(), &region), 0);
-		} while (region.offset != offset);
-
+			pmemstream_region_iterator_get(riter.get(), &region);
+		} while (region.offset != offset && pmemstream_region_iterator_next(riter.get()) == 0);
+		UT_ASSERTeq(region.offset, offset);
 		return stream.region_free(region);
 	}
 

--- a/tests/integrity/multi_region_pmreorder.cpp
+++ b/tests/integrity/multi_region_pmreorder.cpp
@@ -54,12 +54,12 @@ void check_consistency(test_config_type test_config)
 
 	auto riter = s.sut.region_iterator();
 	int region_counter = -1;
-	int ret = 0;
 	do {
-		++region_counter;
 		struct pmemstream_region region;
-		ret = pmemstream_region_iterator_next(riter.get(), &region);
-	} while (ret == 0);
+		if (pmemstream_region_iterator_get(riter.get(), &region) == 0) {
+			++region_counter;
+		}
+	} while (pmemstream_region_iterator_next(riter.get()) == 0);
 
 	// XXX: investigate consistency assurance
 	// struct pmemstream_region region;

--- a/tests/unittest/create.cpp
+++ b/tests/unittest/create.cpp
@@ -75,11 +75,11 @@ int main(int argc, char *argv[])
 				auto riter = stream.sut.region_iterator();
 
 				struct pmemstream_region r;
-				int ret = pmemstream_region_iterator_next(riter.get(), &r);
+				int ret = pmemstream_region_iterator_get(riter.get(), &r);
 				UT_ASSERTeq(ret, 0);
 				UT_ASSERTeq(region.offset, r.offset);
 				/* there should be no more regions */
-				ret = pmemstream_region_iterator_next(riter.get(), &r);
+				ret = pmemstream_region_iterator_next(riter.get());
 				UT_ASSERTeq(ret, -1);
 
 				UT_ASSERTeq(stream.sut.region_free(region), 0);

--- a/tests/unittest/multi_region_state.cpp
+++ b/tests/unittest/multi_region_state.cpp
@@ -124,16 +124,18 @@ struct rc_iterate_regions : regions_command {
 		auto it = s.sut.region_iterator();
 		size_t regions_count = 0;
 		struct pmemstream_region region;
-		while (pmemstream_region_iterator_next(it.get(), &region) != -1) {
-			/* in each region we expect only 1 entry (storing the unique id) */
-			auto entries = s.helpers.get_elements_in_region(region);
-			RC_ASSERT(entries.size() == 1);
+		do {
+			if (pmemstream_region_iterator_get(it.get(), &region) == 0) {
+				/* in each region we expect only 1 entry (storing the unique id) */
+				auto entries = s.helpers.get_elements_in_region(region);
+				RC_ASSERT(entries.size() == 1);
 
-			auto data = reinterpret_cast<const struct entry_data *>(entries.back().data());
+				auto data = reinterpret_cast<const struct entry_data *>(entries.back().data());
 
-			RC_ASSERT(m.allocated_regions[regions_count] == data->data);
-			regions_count++;
-		}
+				RC_ASSERT(m.allocated_regions[regions_count] == data->data);
+				regions_count++;
+			}
+		} while (pmemstream_region_iterator_next(it.get()) != -1);
 		RC_ASSERT(regions_count == m.allocated_regions.size());
 	}
 };


### PR DESCRIPTION
Iterator API proposal 
Changes in iterator behavior:
1. Getter returns region, which is pointed by iterator, so it's possible to store only iterators in some struct, and always get region from it. 
2.  Iterator never points to INVALID_REGION -  if `region_iterator_next()` fail it means there is no more regions in the stream. However if new region is created it's possible to reach it without discarding existing iterator object.    

TODO: 
- [x] Fix tests and examples 
- [ ] Refactor entry iterator in similar manner  as another PR

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemstream/166)
<!-- Reviewable:end -->
