### PR TITLE
Revert "refactor region iterator"

### DIFF
--- a/examples/01_basic_iterate/main.c
+++ b/examples/01_basic_iterate/main.c
@@ -44,13 +44,10 @@ int main(int argc, char *argv[])
 		return ret;
 	}
 
-	/* Iterate over all regions. */
-	do {
-		struct pmemstream_region region;
-		if (pmemstream_region_iterator_get(riter, &region) != 0) {
-			break;
-		}
+	struct pmemstream_region region;
 
+	/* Iterate over all regions. */
+	while (pmemstream_region_iterator_next(riter, &region) == 0) {
 		struct pmemstream_entry entry;
 		struct pmemstream_entry_iterator *eiter;
 		ret = pmemstream_entry_iterator_new(&eiter, stream, region);
@@ -76,7 +73,7 @@ int main(int argc, char *argv[])
 			fprintf(stderr, "pmemstream_append failed\n");
 			return ret;
 		}
-	} while (pmemstream_region_iterator_next(riter) == 0);
+	}
 
 	pmemstream_region_iterator_delete(&riter);
 

--- a/examples/02_visual_iterator/main.cpp
+++ b/examples/02_visual_iterator/main.cpp
@@ -34,6 +34,7 @@ void print_help(const char *exec_filename)
 int main(int argc, char *argv[])
 {
 	bool values_as_text = false;
+	struct pmemstream_region region;
 
 	if (argc < 2 || argc > 3) {
 		print_help(argv[0]);
@@ -70,12 +71,7 @@ int main(int argc, char *argv[])
 
 	/* Iterate over all regions. */
 	size_t region_id = 0;
-	do {
-		struct pmemstream_region region;
-		if (pmemstream_region_iterator_get(riter, &region) != 0) {
-			break;
-		}
-
+	while (pmemstream_region_iterator_next(riter, &region) == 0) {
 		struct pmemstream_entry entry;
 		struct pmemstream_entry_iterator *eiter;
 		ret = pmemstream_entry_iterator_new(&eiter, stream, region);
@@ -105,7 +101,7 @@ int main(int argc, char *argv[])
 			printf("\n");
 		}
 		pmemstream_entry_iterator_delete(&eiter);
-	} while (pmemstream_region_iterator_next(riter) == 0);
+	}
 
 	pmemstream_region_iterator_delete(&riter);
 	pmemstream_delete(&stream);

--- a/examples/04_basic_async/main.cpp
+++ b/examples/04_basic_async/main.cpp
@@ -50,11 +50,7 @@ int main(int argc, char *argv[])
 
 	int i = 0;
 	for (; i < EXAMPLE_ASYNC_COUNT; ++i) {
-		ret = pmemstream_region_iterator_get(riter, &regions[i]);
-		if (ret != 0) {
-			break;
-		}
-		ret = pmemstream_region_iterator_next(riter);
+		ret = pmemstream_region_iterator_next(riter, &regions[i]);
 		if (ret != 0) {
 			break;
 		}

--- a/src/include/libpmemstream.h
+++ b/src/include/libpmemstream.h
@@ -151,9 +151,7 @@ size_t pmemstream_entry_length(struct pmemstream *stream, struct pmemstream_entr
 
 int pmemstream_region_iterator_new(struct pmemstream_region_iterator **iterator, struct pmemstream *stream);
 
-int pmemstream_region_iterator_next(struct pmemstream_region_iterator *iterator);
-
-int pmemstream_region_iterator_get(struct pmemstream_region_iterator *iterator, struct pmemstream_region *region);
+int pmemstream_region_iterator_next(struct pmemstream_region_iterator *iterator, struct pmemstream_region *region);
 
 void pmemstream_region_iterator_delete(struct pmemstream_region_iterator **iterator);
 

--- a/src/iterator.c
+++ b/src/iterator.c
@@ -30,29 +30,7 @@ int pmemstream_region_iterator_new(struct pmemstream_region_iterator **iterator,
 	return 0;
 }
 
-int pmemstream_region_iterator_next(struct pmemstream_region_iterator *it)
-{
-	if (!it) {
-		return -1;
-	}
-
-	if (it->region.offset == SLIST_INVALID_OFFSET) {
-		return -1;
-	}
-
-	struct pmemstream_region next_region;
-	next_region.offset = SLIST_NEXT(struct span_region, &it->stream->data, it->region.offset,
-					allocator_entry_metadata.next_allocated);
-
-	if (next_region.offset == SLIST_INVALID_OFFSET) {
-		return -1;
-	}
-
-	it->region.offset = next_region.offset;
-	return 0;
-}
-
-int pmemstream_region_iterator_get(struct pmemstream_region_iterator *it, struct pmemstream_region *region)
+int pmemstream_region_iterator_next(struct pmemstream_region_iterator *it, struct pmemstream_region *region)
 {
 	if (!it) {
 		return -1;
@@ -63,6 +41,11 @@ int pmemstream_region_iterator_get(struct pmemstream_region_iterator *it, struct
 	}
 
 	*region = it->region;
+
+	/* XXX: hide this in allocator? */
+	/* XXX: lock */
+	it->region.offset = SLIST_NEXT(struct span_region, &it->stream->data, it->region.offset,
+				       allocator_entry_metadata.next_allocated);
 	return 0;
 }
 

--- a/src/libpmemstream.map
+++ b/src/libpmemstream.map
@@ -16,7 +16,6 @@ LIBPMEMSTREAM_1.0 {
 		pmemstream_region_iterator_delete;
 		pmemstream_region_iterator_new;
 		pmemstream_region_iterator_next;
-		pmemstream_region_iterator_get;
 		pmemstream_region_size;
 		pmemstream_append;
 		pmemstream_publish;

--- a/tests/api_c/region_iterator.c
+++ b/tests/api_c/region_iterator.c
@@ -25,10 +25,10 @@ void valid_input_test(char *path)
 	UT_ASSERTeq(ret, 0);
 	UT_ASSERTne(riter, NULL);
 
-	ret = pmemstream_region_iterator_get(riter, &region);
+	ret = pmemstream_region_iterator_next(riter, &region);
 	UT_ASSERTeq(ret, 0);
 
-	ret = pmemstream_region_iterator_next(riter);
+	ret = pmemstream_region_iterator_next(riter, &region);
 	UT_ASSERTeq(ret, -1);
 
 	pmemstream_region_iterator_delete(&riter);
@@ -50,28 +50,28 @@ void null_iterator_test(char *path)
 	ret = pmemstream_region_iterator_new(NULL, env.stream);
 	UT_ASSERTeq(ret, -1);
 
-	ret = pmemstream_region_iterator_get(NULL, &region);
+	ret = pmemstream_region_iterator_next(NULL, &region);
 	UT_ASSERTeq(ret, -1);
 
 	pmemstream_region_free(env.stream, region);
 	pmemstream_test_teardown(env);
 }
 
-void no_allocated_regions_test(char *path)
+void invalid_region_test(char *path)
 {
 	pmemstream_test_env env = pmemstream_test_make_default(path);
 
-	const uint64_t arbitrary_offset = 42;
+	const uint64_t invalid_offset = ALIGN_DOWN(UINT64_MAX, sizeof(span_bytes));
 	struct pmemstream_region_iterator *riter = NULL;
-	struct pmemstream_region region = {.offset = arbitrary_offset};
+	struct pmemstream_region invalid_region = {.offset = invalid_offset};
 
 	int ret = pmemstream_region_iterator_new(&riter, env.stream);
 	UT_ASSERTeq(ret, 0);
 	UT_ASSERTne(riter, NULL);
 
-	ret = pmemstream_region_iterator_get(riter, &region);
+	ret = pmemstream_region_iterator_next(riter, &invalid_region);
 	UT_ASSERTeq(ret, -1);
-	UT_ASSERTeq(region.offset, arbitrary_offset);
+	UT_ASSERTeq(invalid_region.offset, invalid_offset);
 
 	pmemstream_region_iterator_delete(&riter);
 	pmemstream_test_teardown(env);
@@ -101,7 +101,7 @@ int main(int argc, char *argv[])
 
 	valid_input_test(path);
 	null_iterator_test(path);
-	no_allocated_regions_test(path);
+	invalid_region_test(path);
 	null_stream_test();
 
 	return 0;

--- a/tests/integrity/multi_region_pmreorder.cpp
+++ b/tests/integrity/multi_region_pmreorder.cpp
@@ -54,12 +54,12 @@ void check_consistency(test_config_type test_config)
 
 	auto riter = s.sut.region_iterator();
 	int region_counter = -1;
+	int ret = 0;
 	do {
+		++region_counter;
 		struct pmemstream_region region;
-		if (pmemstream_region_iterator_get(riter.get(), &region) == 0) {
-			++region_counter;
-		}
-	} while (pmemstream_region_iterator_next(riter.get()) == 0);
+		ret = pmemstream_region_iterator_next(riter.get(), &region);
+	} while (ret == 0);
 
 	// XXX: investigate consistency assurance
 	// struct pmemstream_region region;

--- a/tests/unittest/create.cpp
+++ b/tests/unittest/create.cpp
@@ -75,11 +75,11 @@ int main(int argc, char *argv[])
 				auto riter = stream.sut.region_iterator();
 
 				struct pmemstream_region r;
-				int ret = pmemstream_region_iterator_get(riter.get(), &r);
+				int ret = pmemstream_region_iterator_next(riter.get(), &r);
 				UT_ASSERTeq(ret, 0);
 				UT_ASSERTeq(region.offset, r.offset);
 				/* there should be no more regions */
-				ret = pmemstream_region_iterator_next(riter.get());
+				ret = pmemstream_region_iterator_next(riter.get(), &r);
 				UT_ASSERTeq(ret, -1);
 
 				UT_ASSERTeq(stream.sut.region_free(region), 0);

--- a/tests/unittest/multi_region_state.cpp
+++ b/tests/unittest/multi_region_state.cpp
@@ -124,18 +124,16 @@ struct rc_iterate_regions : regions_command {
 		auto it = s.sut.region_iterator();
 		size_t regions_count = 0;
 		struct pmemstream_region region;
-		do {
-			if (pmemstream_region_iterator_get(it.get(), &region) == 0) {
-				/* in each region we expect only 1 entry (storing the unique id) */
-				auto entries = s.helpers.get_elements_in_region(region);
-				RC_ASSERT(entries.size() == 1);
+		while (pmemstream_region_iterator_next(it.get(), &region) != -1) {
+			/* in each region we expect only 1 entry (storing the unique id) */
+			auto entries = s.helpers.get_elements_in_region(region);
+			RC_ASSERT(entries.size() == 1);
 
-				auto data = reinterpret_cast<const struct entry_data *>(entries.back().data());
+			auto data = reinterpret_cast<const struct entry_data *>(entries.back().data());
 
-				RC_ASSERT(m.allocated_regions[regions_count] == data->data);
-				regions_count++;
-			}
-		} while (pmemstream_region_iterator_next(it.get()) != -1);
+			RC_ASSERT(m.allocated_regions[regions_count] == data->data);
+			regions_count++;
+		}
 		RC_ASSERT(regions_count == m.allocated_regions.size());
 	}
 };


### PR DESCRIPTION
Revert this since changing API for entry_iterator will take longer. We should make patch which changes both entry and region iterator.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemstream/170)
<!-- Reviewable:end -->
