### PR TITLE
Add support for shrinkable number of threads in RC tests

### DIFF
--- a/tests/common/rapidcheck_helpers.hpp
+++ b/tests/common/rapidcheck_helpers.hpp
@@ -62,6 +62,22 @@ struct rc_verify_command : public pmemstream_command {
 	}
 };
 
+/* Holds integer value between Min ans Max (inclusive) */
+template <typename T, size_t Min, size_t Max>
+struct ranged {
+	static constexpr T min = Min;
+	static constexpr T max = Max;
+	T value;
+
+	ranged(T val)
+	{
+		if (val < min || val > max) {
+			throw std::runtime_error("Improper value");
+		}
+		value = val;
+	}
+};
+
 /* Generators for custom structures. */
 namespace rc
 {
@@ -111,6 +127,14 @@ struct Arbitrary<pmemstream_with_single_init_region> {
 	{
 		return gen::noShrink(gen::construct<pmemstream_with_single_init_region>(
 			gen::arbitrary<pmemstream_test_base>(), gen::arbitrary<std::vector<std::string>>()));
+	}
+};
+
+template <typename T, size_t Min, size_t Max>
+struct Arbitrary<ranged<T, Min, Max>> {
+	static Gen<ranged<T, Min, Max>> arbitrary()
+	{
+		return gen::construct<ranged<T, Min, Max>>(gen::inRange<T>(Min, Max + 1));
 	}
 };
 


### PR DESCRIPTION
In some tests, like concurrent_iterate, it's useful to get ability to
test against different (random) number of threads.

TODO:

- [ ]  Use it in more tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemstream/194)
<!-- Reviewable:end -->
