### PR TITLE
set initial persisted timestamp as 'INVALID_TIMESTAMP + 1'

### DIFF
--- a/src/libpmemstream.c
+++ b/src/libpmemstream.c
@@ -37,7 +37,7 @@ static void pmemstream_init(struct pmemstream *stream)
 
 	stream->header->stream_size = stream->stream_size;
 	stream->header->block_size = stream->block_size;
-	stream->header->persisted_timestamp = PMEMSTREAM_INVALID_TIMESTAMP;
+	stream->header->persisted_timestamp = PMEMSTREAM_INVALID_TIMESTAMP + 1;
 	stream->data.persist(stream->header, sizeof(struct pmemstream_header));
 
 	stream->data.memcpy(stream->header->signature, PMEMSTREAM_SIGNATURE, strlen(PMEMSTREAM_SIGNATURE),

--- a/src/region.c
+++ b/src/region.c
@@ -335,6 +335,10 @@ static bool check_entry_consistency(struct pmemstream_entry_iterator *iterator)
 	if (committed_timestamp < max_valid_timestamp || max_valid_timestamp == PMEMSTREAM_INVALID_TIMESTAMP)
 		max_valid_timestamp = committed_timestamp;
 
+	if (span_entry->timestamp == PMEMSTREAM_INVALID_TIMESTAMP) {
+		return false;
+	}
+
 	if (span_entry->timestamp < max_valid_timestamp) {
 		return true;
 	}


### PR DESCRIPTION
Previously we set persisted timestamp to 0, which is then used
for the first entry. That entry ended up with the invalid timestamp.
Along with this change add a check (in the recovery) to check if currently
checked entry isn't timestamped as invalid.