### PR TITLE
[API] Add pmemstream_entry_timestamp()

### DIFF
--- a/src/include/libpmemstream.h
+++ b/src/include/libpmemstream.h
@@ -149,6 +149,9 @@ const void *pmemstream_entry_data(struct pmemstream *stream, struct pmemstream_e
 /* Returns the size of the entry. Assumes that 'entry' points to a valid entry. */
 size_t pmemstream_entry_length(struct pmemstream *stream, struct pmemstream_entry entry);
 
+/* Returns timestamp related with entry */
+uint64_t pmemstream_entry_timestamp(struct pmemstream *stream, struct pmemstream_entry entry);
+
 /* Creates new region iterator
  *
  * Default state is undefined: every new iterator should be moved to first element in the stream.

--- a/src/libpmemstream.c
+++ b/src/libpmemstream.c
@@ -313,6 +313,16 @@ size_t pmemstream_entry_length(struct pmemstream *stream, struct pmemstream_entr
 	return span_get_size(&span_entry->span_base);
 }
 
+uint64_t pmemstream_entry_timestamp(struct pmemstream *stream, struct pmemstream_entry entry)
+{
+	int ret = pmemstream_validate_stream_and_offset(stream, entry.offset);
+	if (ret) {
+		return PMEMSTREAM_INVALID_TIMESTAMP;
+	}
+	struct span_entry *span_entry = (struct span_entry *)span_offset_to_span_ptr(&stream->data, entry.offset);
+	return span_entry->timestamp;
+}
+
 int pmemstream_region_runtime_initialize(struct pmemstream *stream, struct pmemstream_region region,
 					 struct pmemstream_region_runtime **region_runtime)
 {

--- a/src/libpmemstream.map
+++ b/src/libpmemstream.map
@@ -15,6 +15,7 @@ LIBPMEMSTREAM_1.0 {
 		pmemstream_entry_iterator_new;
 		pmemstream_entry_iterator_next;
 		pmemstream_entry_length;
+		pmemstream_entry_timestamp;
 		pmemstream_from_map;
 		pmemstream_persisted_timestamp;
 		pmemstream_publish;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -100,6 +100,9 @@ add_test_generic(NAME reserve_and_publish TRACERS none memcheck pmemcheck drd he
 build_test(stream_from_map api_c/stream_from_map.c)
 add_test_generic(NAME stream_from_map TRACERS none memcheck pmemcheck drd helgrind)
 
+build_test(timestamp_api api_c/timestamp.c)
+add_test_generic(NAME timestamp_api TRACERS none memcheck pmemcheck drd helgrind)
+
 if(TESTS_RAPIDCHECK)
 	build_test_rc(NAME append SRC_FILES unittest/append.cpp)
 	add_test_generic(NAME append TRACERS none memcheck pmemcheck)

--- a/tests/api_c/timestamp.c
+++ b/tests/api_c/timestamp.c
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2022, Intel Corporation */
+
+#include "libpmemstream.h"
+#include "libpmemstream_internal.h"
+#include "stream_helpers.h"
+#include "unittest.h"
+
+#include "string.h"
+
+void check_timestamp_and_order(char *path)
+{
+	pmemstream_test_env env = pmemstream_test_make_default(path);
+
+	int ret = 0;
+	uint64_t timestamp = PMEMSTREAM_INVALID_TIMESTAMP;
+	struct pmemstream_entry entry = {.offset = PMEMSTREAM_INVALID_OFFSET};
+	struct pmemstream_region region = {.offset = PMEMSTREAM_INVALID_OFFSET};
+	const char *data = "some_entry_data";
+
+	ret = pmemstream_region_allocate(env.stream, TEST_DEFAULT_REGION_SIZE, &region);
+	UT_ASSERTeq(ret, 0);
+	for (size_t i = 0; i < 10; i++) {
+		ret = pmemstream_append(env.stream, region, NULL, data, strlen(data), &entry);
+		UT_ASSERTeq(ret, 0);
+		UT_ASSERTne(entry.offset, PMEMSTREAM_INVALID_OFFSET);
+
+		timestamp = pmemstream_entry_timestamp(env.stream, entry);
+		UT_ASSERTne(timestamp, PMEMSTREAM_INVALID_TIMESTAMP);
+		UT_ASSERTeq(timestamp, PMEMSTREAM_FIRST_TIMESTAMP + i);
+	}
+
+	pmemstream_region_free(env.stream, region);
+	pmemstream_test_teardown(env);
+}
+
+int main(int argc, char *argv[])
+{
+	if (argc < 2) {
+		UT_FATAL("usage: %s file-name", argv[0]);
+	}
+	char *path = argv[1];
+
+	START();
+	check_timestamp_and_order(path);
+
+	return 0;
+}


### PR DESCRIPTION
This function returns the timestamp assigned to the entry.

Closes #202.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemstream/205)
<!-- Reviewable:end -->
