### PR TITLE
tests: use rc ranged generator for concurrency

### DIFF
--- a/tests/common/rapidcheck_helpers.hpp
+++ b/tests/common/rapidcheck_helpers.hpp
@@ -62,7 +62,7 @@ struct rc_verify_command : public pmemstream_command {
 	}
 };
 
-/* Holds integer value between Min ans Max (inclusive) */
+/* Holds integer value between Min and Max (inclusive) */
 template <typename T, size_t Min, size_t Max>
 struct ranged {
 	static constexpr T min = Min;

--- a/tests/unittest/concurrent_iterate.cpp
+++ b/tests/unittest/concurrent_iterate.cpp
@@ -10,7 +10,6 @@
 #include "thread_helpers.hpp"
 #include "unittest.hpp"
 
-static constexpr size_t min_concurrency = 1;
 static constexpr size_t max_concurrency = 12;
 
 int main(int argc, char *argv[])
@@ -29,7 +28,7 @@ int main(int argc, char *argv[])
 		ret += rc::check(
 			"verify if each concurrent iteration observes the same data",
 			[&](const std::vector<std::string> &data, bool reopen,
-			    ranged<size_t, min_concurrency, max_concurrency> concurrency) {
+			    ranged<size_t, 1, max_concurrency> concurrency) {
 				pmemstream_test_base stream(get_test_config().filename, get_test_config().block_size,
 							    get_test_config().stream_size);
 				auto region = stream.helpers.initialize_single_region(TEST_DEFAULT_REGION_SIZE, data);

--- a/tests/unittest/region_runtime_initialize.cpp
+++ b/tests/unittest/region_runtime_initialize.cpp
@@ -28,9 +28,8 @@ int main(int argc, char *argv[])
 		return_check ret;
 
 		ret += rc::check(
-			"verify pmemstream_region_runtime_initialize return the same value for all threads", [&]() {
-				const auto concurrency = *rc::gen::inRange<std::size_t>(1, max_concurrency);
-
+			"verify pmemstream_region_runtime_initialize return the same value for all threads",
+			[&](ranged<size_t, 1, max_concurrency> concurrency) {
 				pmemstream_test_base stream(get_test_config().filename, get_test_config().block_size,
 							    get_test_config().stream_size);
 				auto region = stream.helpers.initialize_single_region(TEST_DEFAULT_REGION_SIZE, {});
@@ -50,11 +49,9 @@ int main(int argc, char *argv[])
 
 		ret += rc::check(
 			"verify that pmemstream is ready to be written to after region_runtime_initialize_for_write_locked",
-			[&](pmemstream_with_single_init_region &&stream) {
-				const auto concurrency = *rc::gen::inRange<std::size_t>(0, max_concurrency);
-
+			[&](pmemstream_with_single_init_region &&stream,
+			    ranged<size_t, 1, max_concurrency> concurrency) {
 				stream.reopen();
-
 				auto region = stream.helpers.get_first_region();
 
 				auto *c_stream = stream.sut.c_ptr();


### PR DESCRIPTION
It allows generating concurrency in range and be a shrinkable property.
It's useful when debugging a failing test, e.g. to get info on how many
threads are too much.

Fixes: #203