### PR TITLE
Fix race in iterator (entry validation)

### DIFF
--- a/src/region.c
+++ b/src/region.c
@@ -43,20 +43,6 @@ struct pmemstream_region_runtime {
 	 */
 	uint64_t append_offset;
 
-	/*
-	 * All entries which start at offset < committed_offset can be treated as committed and safely read
-	 * from multiple threads.
-	 *
-	 * XXX: committed offset is not reliable in case of concurrent appends to the same region. The reason is
-	 * that it is updated in pmemstream_publish/pmemstream_sync, potentially in different order than append_offset.
-	 *
-	 * To fix this, we might use mechanism similar to timestamp tracking. Alternatively we can batch (transparently
-	 * or via a transaction) appends and then, increase committed_offset on batch commit.
-	 *
-	 * XXX: add test for this: async_append entries of different sizes and call future_poll in different order.
-	 */
-	uint64_t committed_offset;
-
 	/* Protects region initialization step. */
 	pthread_mutex_t region_lock;
 };
@@ -122,7 +108,6 @@ static int region_runtimes_map_create_or_fail(struct region_runtimes_map *map, s
 	runtime->region = region;
 	runtime->state = REGION_RUNTIME_STATE_READ_READY;
 	runtime->append_offset = PMEMSTREAM_INVALID_OFFSET;
-	runtime->committed_offset = PMEMSTREAM_INVALID_OFFSET;
 
 	int ret = pthread_mutex_init(&runtime->region_lock, NULL);
 	if (ret) {
@@ -187,12 +172,6 @@ uint64_t region_runtime_get_append_offset_acquire(const struct pmemstream_region
 	return __atomic_load_n(&region_runtime->append_offset, __ATOMIC_ACQUIRE);
 }
 
-static uint64_t region_runtime_get_committed_offset_acquire(const struct pmemstream_region_runtime *region_runtime)
-{
-	assert(region_runtime_get_state_acquire(region_runtime) == REGION_RUNTIME_STATE_WRITE_READY);
-	return __atomic_load_n(&region_runtime->committed_offset, __ATOMIC_ACQUIRE);
-}
-
 void region_runtimes_map_remove(struct region_runtimes_map *map, struct pmemstream_region region)
 {
 	struct pmemstream_region_runtime *runtime = critnib_remove(map->container, region.offset);
@@ -205,12 +184,6 @@ void region_runtime_increase_append_offset(struct pmemstream_region_runtime *reg
 	__atomic_fetch_add(&region_runtime->append_offset, diff, __ATOMIC_RELAXED);
 }
 
-void region_runtime_increase_committed_offset(struct pmemstream_region_runtime *region_runtime, uint64_t diff)
-{
-	assert(region_runtime_get_state_acquire(region_runtime) == REGION_RUNTIME_STATE_WRITE_READY);
-	__atomic_fetch_add(&region_runtime->committed_offset, diff, __ATOMIC_RELEASE);
-}
-
 static void region_runtime_initialize_for_write_no_lock(struct pmemstream_region_runtime *region_runtime,
 							uint64_t tail_offset)
 {
@@ -220,7 +193,6 @@ static void region_runtime_initialize_for_write_no_lock(struct pmemstream_region
 	assert(tail_offset != PMEMSTREAM_INVALID_OFFSET);
 
 	region_runtime->append_offset = tail_offset;
-	region_runtime->committed_offset = tail_offset;
 
 	uint8_t *next_entry_dst = (uint8_t *)pmemstream_offset_to_ptr(region_runtime->data, tail_offset);
 	region_runtime->data->memset(next_entry_dst, 0, sizeof(struct span_entry), 0);
@@ -317,29 +289,25 @@ static bool check_entry_consistency(struct pmemstream_entry_iterator *iterator)
 		return false;
 	}
 
-	/* XXX: reading this span metadata is potentially dangerous. It might happen so that
-	 * before calling this function region_runtime is in READ_READY state but some other thread
-	 * changes it to WRITE_READY while span metadata is read. We might fix this using Optimistic Locking.
-	 */
-	const struct span_base *span_base = span_offset_to_span_ptr(&iterator->stream->data, iterator->offset);
-	if (span_get_type(span_base) != SPAN_ENTRY) {
-		return false;
-	}
-
-	const struct span_entry *span_entry = (const struct span_entry *)span_base;
-
 	/* XXX: max timestamp should be passed to iterator */
 	uint64_t committed_timestamp = pmemstream_committed_timestamp(iterator->stream);
-	uint64_t max_valid_timestamp = __atomic_load_n(&span_region->max_valid_timestamp, __ATOMIC_ACQUIRE);
-
+	uint64_t max_valid_timestamp = __atomic_load_n(&span_region->max_valid_timestamp, __ATOMIC_RELAXED);
 	if (committed_timestamp < max_valid_timestamp || max_valid_timestamp == PMEMSTREAM_INVALID_TIMESTAMP)
 		max_valid_timestamp = committed_timestamp;
 
-	if (span_entry->timestamp == PMEMSTREAM_INVALID_TIMESTAMP) {
+	const struct span_entry *span_entry_ptr =
+		(const struct span_entry *)span_offset_to_span_ptr(&iterator->stream->data, iterator->offset);
+	struct span_entry span_entry = span_entry_atomic_load(span_entry_ptr);
+
+	if (span_get_type(&span_entry.span_base) != SPAN_ENTRY) {
 		return false;
 	}
 
-	if (span_entry->timestamp <= max_valid_timestamp) {
+	if (span_entry.timestamp == PMEMSTREAM_INVALID_TIMESTAMP) {
+		return false;
+	}
+
+	if (span_entry.timestamp <= max_valid_timestamp) {
 		return true;
 	}
 
@@ -348,23 +316,9 @@ static bool check_entry_consistency(struct pmemstream_entry_iterator *iterator)
 
 bool check_entry_and_maybe_recover_region(struct pmemstream_entry_iterator *iterator)
 {
-	if (region_runtime_get_state_acquire(iterator->region_runtime) == REGION_RUNTIME_STATE_READ_READY) {
-		bool valid_entry = check_entry_consistency(iterator);
-		if (!valid_entry && iterator->perform_recovery) {
-			region_runtime_initialize_for_write_locked(iterator->region_runtime, iterator->offset);
-		}
-		return valid_entry;
+	bool valid_entry = check_entry_consistency(iterator);
+	if (!valid_entry && iterator->perform_recovery) {
+		region_runtime_initialize_for_write_locked(iterator->region_runtime, iterator->offset);
 	}
-
-	/* Make sure that we didn't go beyond committed entries. */
-	uint64_t committed_offset = region_runtime_get_committed_offset_acquire(iterator->region_runtime);
-	if (iterator->offset >= committed_offset) {
-		return false;
-	}
-
-	/* Region is already recovered, and we did not encounter end of the data yet.
-	 * Span must be a valid entry. */
-	assert(check_entry_consistency(iterator));
-
-	return true;
+	return valid_entry;
 }

--- a/src/region.h
+++ b/src/region.h
@@ -39,8 +39,6 @@ uint64_t region_runtime_get_append_offset_acquire(const struct pmemstream_region
 
 /* Precondition: region_runtime_iterate_and_initialize_for_write_locked must have been called. */
 void region_runtime_increase_append_offset(struct pmemstream_region_runtime *region_runtime, uint64_t diff);
-/* Precondition: region_runtime_iterate_and_initialize_for_write_locked must have been called. */
-void region_runtime_increase_committed_offset(struct pmemstream_region_runtime *region_runtime, uint64_t diff);
 
 /*
  * Performs region recovery. This function iterates over entire region to find last entry and set append/committed

--- a/src/span.c
+++ b/src/span.c
@@ -44,3 +44,42 @@ enum span_type span_get_type(const struct span_base *span)
 {
 	return span->size_and_type & SPAN_TYPE_MASK;
 }
+
+/* Following atomic store/load functions are protected by appropriate fences.
+ * They make sure that no load/store operation (issued either before or after)
+ * can be reorder with storing/loading span metadata.
+ *
+ * Release fence prohibits reordering stores in any direction.
+ * Acquire fence prohibits reordering loads in any direction.
+ */
+void span_base_atomic_store(struct span_base *dst, struct span_base base)
+{
+	__atomic_thread_fence(__ATOMIC_RELEASE);
+
+	__atomic_store_n(&dst->size_and_type, base.size_and_type, __ATOMIC_RELAXED);
+
+	__atomic_thread_fence(__ATOMIC_RELEASE);
+}
+
+void span_entry_atomic_store(struct span_entry *dst, struct span_entry entry)
+{
+	__atomic_thread_fence(__ATOMIC_RELEASE);
+
+	__atomic_store_n(&dst->span_base.size_and_type, entry.span_base.size_and_type, __ATOMIC_RELAXED);
+	__atomic_store_n(&dst->timestamp, entry.timestamp, __ATOMIC_RELAXED);
+
+	__atomic_thread_fence(__ATOMIC_RELEASE);
+}
+
+struct span_entry span_entry_atomic_load(const struct span_entry *entry_ptr)
+{
+	__atomic_thread_fence(__ATOMIC_ACQUIRE);
+
+	struct span_entry entry;
+	entry.span_base.size_and_type = __atomic_load_n(&entry_ptr->span_base.size_and_type, __ATOMIC_RELAXED);
+	entry.timestamp = __atomic_load_n(&entry_ptr->timestamp, __ATOMIC_RELAXED);
+
+	__atomic_thread_fence(__ATOMIC_ACQUIRE);
+
+	return entry;
+}

--- a/src/span.h
+++ b/src/span.h
@@ -71,6 +71,11 @@ size_t span_get_total_size(const struct span_base *span);
 
 enum span_type span_get_type(const struct span_base *span);
 
+void span_base_atomic_store(struct span_base *dst, struct span_base base);
+
+void span_entry_atomic_store(struct span_entry *dst, struct span_entry entry);
+struct span_entry span_entry_atomic_load(const struct span_entry *entry);
+
 #ifdef __cplusplus
 } /* end extern "C" */
 #endif


### PR DESCRIPTION
Get rid of committed_offset and rely only on committed_timestamp.
Use atomic stores/loads to read entry metadata.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemstream/208)
<!-- Reviewable:end -->
