### PR TITLE
Update span helpers and extend debugging docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,6 +141,8 @@ To enable automatic images pushing to GitHub Container Registry, following varia
 
 # Debugging
 
+## GDB
+
 Test framework supports debugging under gdb.
 
 * For remote debugging set `GDBSERVER` environment variable. Its content will be passed to gdbserver
@@ -151,4 +153,18 @@ Example usage with a single test:
 GDBSERVER=localhost:4444 ctest -R vector_comp_operators_0_none --output-on-failure
 ```
 
-* For local debugging in graphical environment using cgdb, set `CGDB` environment variable to `gnome-terminal` or `konsole` accordingly to your setup.
+* For local debugging in graphical environment using cgdb, set `CGDB` environment variable to
+`gnome-terminal` or `konsole` accordingly to your setup.
+
+## Tests helpers
+
+When something unexpected appears in the pmemstream, e.g., entries' count does not match expectation or
+a trash spans are encountered - it is possible to easily print the content of stream's file.
+There's available a tests helper class - `stream_span_helpers.hpp` which provides a quick way
+to gather information of all spans (entries, regions, empty spaces) recognized within the stream.
+It's simply possible to print this content by running C++ code like this (from a gdb or example code):
+
+```cpp
+auto spans = span_runtimes_from_stream(stream);
+std::cout << spans << std::endl;
+```

--- a/tests/README.md
+++ b/tests/README.md
@@ -7,10 +7,11 @@ hand C tests are checking usage in C applications, which are default for C API.
 Directories contains:
 - **abi** - tests for ABI,
 - **api_c** - plain tests for C API,
+- **benchmarks** - test files for executing benchmarks,
 - **cmake** - CMake and ctest helpers, including suppressions' files and CMake executions scripts,
 - **common** - shared functions and libraries for all tests,
-- **layout** - tests which require knowledge about stream layout.
 - **integrity** - data integrity tests (using e.g. gdb or pmreorder),
+- **layout** - tests which require knowledge about stream layout,
 - **unittest** - unit tests for various (e.g. internal) functionalities.
 
 # Tests execution
@@ -35,3 +36,9 @@ ctest --output-on-failure
 
 There are other parameters to use in `ctest` command. To see the full list read
 [ctest(1) manpage](https://cmake.org/cmake/help/latest/manual/ctest.1.html).
+
+# Debugging
+
+Testing is strongly connected with debugging issues encountered in pmemstream.
+If you need an assistance with it, there are some useful hints, gathered in our
+short ["Debugging" sub-section of CONTRIBUTING.md](../CONTRIBUTING.md#Debugging).

--- a/tests/common/stream_helpers.hpp
+++ b/tests/common/stream_helpers.hpp
@@ -598,7 +598,7 @@ static inline std::ostream &operator<<(std::ostream &os, const pmemstream_test_b
 	os << "call_initialize_region_runtime: " << stream.call_initialize_region_runtime << std::endl;
 	os << "call_initialize_region_runtime_after_reopen: " << stream.call_initialize_region_runtime_after_reopen
 	   << std::endl;
-	os << span_runtimes_from_stream(stream.sut, 0, UINT64_MAX);
+	os << span_runtimes_from_stream(stream.sut);
 	return os;
 }
 

--- a/tests/common/stream_span_helpers.cpp
+++ b/tests/common/stream_span_helpers.cpp
@@ -39,9 +39,16 @@ std::string span_to_str(const struct span_base *base)
 {
 	std::map<uint64_t, const std::string> span_type_names = {{SPAN_ENTRY, std::string("entry")},
 								 {SPAN_REGION, std::string("region")},
-								 {SPAN_EMPTY, std::string("empty")}};
+								 {SPAN_EMPTY, std::string("empty")},
+								 {SPAN_UNKNOWN, std::string("unknown")}};
 
-	return "type: " + span_type_names[span_get_type(base)] + ", data size: " + std::to_string(span_get_size(base));
+	span_type type = span_get_type(base);
+	std::string span_str = "type: " + span_type_names[type] + ", data size: " + std::to_string(span_get_size(base));
+	if (type == SPAN_ENTRY) {
+		auto entry = (const struct span_entry *)base;
+		span_str += ", timestamp: " + std::to_string(entry->timestamp);
+	}
+	return span_str;
 }
 
 std::ostream &operator<<(std::ostream &os, const struct span_base *base)

--- a/tests/common/stream_span_helpers.cpp
+++ b/tests/common/stream_span_helpers.cpp
@@ -7,6 +7,8 @@
 #include "../src/span.h"
 #include "stream_helpers.hpp"
 
+/* get all span's within given offset range;
+ * offsets' params are optional - by default scan the whole stream */
 std::vector<span_runtime> span_runtimes_from_stream(const pmem::stream &stream, size_t offset, size_t end_offset)
 {
 	std::vector<span_runtime> spans;

--- a/tests/common/stream_span_helpers.hpp
+++ b/tests/common/stream_span_helpers.hpp
@@ -19,7 +19,8 @@ struct span_runtime {
 	std::vector<span_runtime> sub_spans;
 };
 
-std::vector<span_runtime> span_runtimes_from_stream(const pmem::stream &stream, size_t offset, size_t end_offset);
+std::vector<span_runtime> span_runtimes_from_stream(const pmem::stream &stream, size_t offset = 0,
+						    size_t end_offset = UINT64_MAX);
 std::string span_to_str(const struct span_base *base);
 std::ostream &operator<<(std::ostream &os, const struct span_base *base);
 std::ostream &operator<<(std::ostream &os, const std::vector<span_runtime> &spans);

--- a/tests/integrity/append_break.cpp
+++ b/tests/integrity/append_break.cpp
@@ -116,7 +116,7 @@ static void test(std::string mode)
 		UT_ASSERTeq(init_data.size() + 1, persisted_timestamp);
 
 		/* check if we have for sure a duplicated timestamp */
-		auto regions = span_runtimes_from_stream(s.sut, 0, UINT64_MAX);
+		auto regions = span_runtimes_from_stream(s.sut);
 
 		/* in the 1. region there should be 4 entry spans (incl. broken one) + potentially 1 empty span */
 		UT_ASSERT(regions[0].sub_spans.size() >= 4);
@@ -153,7 +153,7 @@ static void test(std::string mode)
 
 		/* check if new entries (in both regions) have proper timestamps and each of these
 		 * entries are now followed by an empty span */
-		regions = span_runtimes_from_stream(s.sut, 0, UINT64_MAX);
+		regions = span_runtimes_from_stream(s.sut);
 
 		/* 1. region: 4 entry spans + 1 empty span (+ possible trash) */
 		UT_ASSERT(regions[0].sub_spans.size() >= 5);

--- a/tests/layout/iterate_all.cpp
+++ b/tests/layout/iterate_all.cpp
@@ -39,7 +39,7 @@ int main(int argc, char *argv[])
 				RC_PRE(data.size() > 0);
 				stream.helpers.append(stream.helpers.get_first_region(), data);
 
-				auto span_view = span_runtimes_from_stream(stream.sut, 0, UINT64_MAX);
+				auto span_view = span_runtimes_from_stream(stream.sut);
 				UT_ASSERTeq(span_get_type(span_view[0].ptr), SPAN_REGION);
 				auto &region = span_view[0];
 				auto &entries = region.sub_spans;


### PR DESCRIPTION
example output for printing stream (after recovery):
```
├── offset: 0, type: region, data size: 106432
|   ├── offset: 64, type: entry, data size: 8, timestamp: 1
|   ├── offset: 88, type: entry, data size: 12, timestamp: 2
|   ├── offset: 120, type: entry, data size: 6, timestamp: 3
|   ├── offset: 144, type: entry, data size: 100, timestamp: 5
|   ├── offset: 264, type: empty, data size: 0
|   ├── offset: 272, type: unknown, data size: 4503175759170272894
├── offset: 106496, type: region, data size: 106432
|   ├── offset: 106560, type: entry, data size: 100, timestamp: 4
|   ├── offset: 106680, type: empty, data size: 0
├── offset: 212992, type: empty, data size: 0
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemstream/216)
<!-- Reviewable:end -->
