### PR TITLE
Add support for configuring generated number of regions via test_config

### DIFF
--- a/tests/common/rapidcheck_helpers.hpp
+++ b/tests/common/rapidcheck_helpers.hpp
@@ -148,20 +148,14 @@ struct Arbitrary<pmemstream_with_multi_non_empty_regions> {
 		using RegionT = std::vector<std::string>;
 		using StreamT = std::vector<RegionT>;
 
-		const auto region_generator = gen::container<RegionT>(gen::nonEmpty(gen::arbitrary<std::string>()));
-
 		const auto non_empty_region_generator =
-			gen::suchThat<RegionT>(region_generator, [](const RegionT &data) { return data.size() > 0; });
+			gen::nonEmpty(gen::container<RegionT>(gen::nonEmpty(gen::arbitrary<std::string>())));
 
-		const auto stream_generator = gen::container<StreamT>(non_empty_region_generator);
-		/* XXX: Configure number of regions via testconfig */
-		const auto constrained_stream_generator =
-			gen::suchThat<StreamT>(stream_generator, [](const StreamT &data) {
-				return (data.size() > 0) && (data.size() <= TEST_DEFAULT_REGION_MULTI_MAX_COUNT);
-			});
+		const auto non_empty_stream_generator = gen::nonEmpty(
+			gen::container<StreamT>(get_test_config().regions_count, non_empty_region_generator));
 
 		return gen::noShrink(gen::construct<pmemstream_with_multi_non_empty_regions>(
-			gen::arbitrary<pmemstream_test_base>(), constrained_stream_generator));
+			gen::arbitrary<pmemstream_test_base>(), non_empty_stream_generator));
 	}
 };
 

--- a/tests/common/unittest.hpp
+++ b/tests/common/unittest.hpp
@@ -77,6 +77,7 @@ struct test_config_type {
 	size_t block_size = TEST_DEFAULT_BLOCK_SIZE;
 	/* all regions are required to have the same size */
 	size_t region_size = TEST_DEFAULT_REGION_MULTI_SIZE;
+	size_t regions_count = 1;
 	std::map<std::string, std::string> rc_params;
 };
 

--- a/tests/unittest/concurrent_iterate.cpp
+++ b/tests/unittest/concurrent_iterate.cpp
@@ -26,6 +26,7 @@ int main(int argc, char *argv[])
 	struct test_config_type test_config;
 	test_config.filename = std::string(argv[1]);
 	test_config.stream_size = STREAM_SIZE;
+	test_config.regions_count = TEST_DEFAULT_REGION_MULTI_MAX_COUNT;
 
 	return run_test(test_config, [&] {
 		return_check ret;


### PR DESCRIPTION
Predicate for generating data
```
 (data.size() <= TEST_DEFAULT_REGION_MULTI_MAX_COUNT)
```
was not likely enough, so sometimes caused fails.

Unfortunately it's impossible to pass number generator to `Gen<Container> container(...)`