### PR TITLE
Add libasan/libtsan/libubsan for Fedora 35

### DIFF
--- a/utils/docker/images/fedora-35.Dockerfile
+++ b/utils/docker/images/fedora-35.Dockerfile
@@ -13,6 +13,10 @@ MAINTAINER igor.chorazewicz@intel.com
 # use 'root' while building the image
 USER root
 
+# Install dependency for thread sanitizer
+RUN dnf install -y libasan libtsan libubsan \
+ && dnf clean all
+
 # Install all PMDK packages
 # Use non-released ("custom") version with the fix for proper ndctl header include
 ENV PMDK_VERSION bbd93c8c4c3ca8bc4d1136ad30b3bc15fa78919a


### PR DESCRIPTION
## This PR following:
### UBSAN:
```
-- Performing Test C_HAS_UBSAN
-- Performing Test C_HAS_UBSAN - Failed
-- Performing Test CXX_HAS_UBSAN
-- Performing Test CXX_HAS_UBSAN - Failed
--   undefined sanitizer is not supported (neither by C nor CXX compiler)
```
### ASAN:
```
-- Performing Test C_HAS_ASAN
-- Performing Test C_HAS_ASAN - Failed
-- Performing Test CXX_HAS_ASAN
-- Performing Test CXX_HAS_ASAN - Failed
--   address sanitizer is not supported (neither by C nor CXX compiler)
```
and TSAN from the previous PR.

## Commit:
Due to the lack of sanitizer support in Fedora 35 there is a need
to install it manually.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemstream/241)
<!-- Reviewable:end -->
