### PR TITLE
[helpers] simplify concurrent_type structure

### DIFF
--- a/tests/common/rapidcheck_helpers.hpp
+++ b/tests/common/rapidcheck_helpers.hpp
@@ -96,12 +96,7 @@ struct ranged {
 };
 
 template <size_t Min, size_t Max>
-struct concurrency_type {
-	ranged<size_t, Min, Max> value;
-	operator size_t() const
-	{
-		return value;
-	}
+struct concurrency_type : ranged<size_t, Min, Max> {
 };
 
 /* Generators for custom structures. */


### PR DESCRIPTION
Since concurrent_type implements the same features
as ranged, there is no need to do it twice.