### PR TITLE
Fix GCC ABI warning about flexible array member

### DIFF
--- a/src/region.c
+++ b/src/region.c
@@ -311,17 +311,18 @@ bool check_entry_consistency(const struct pmemstream_entry_iterator *iterator)
 
 	const struct span_entry *span_entry_ptr =
 		(const struct span_entry *)span_offset_to_span_ptr(&iterator->stream->data, iterator->offset);
-	struct span_entry span_entry = span_entry_atomic_load(span_entry_ptr);
+	struct span_timestamped_base span_timestamped =
+		span_timestamped_base_atomic_load(&span_entry_ptr->span_timestamped_base);
 
-	if (span_get_type(&span_entry.span_base) != SPAN_ENTRY) {
+	if (span_get_type(&span_timestamped.span_base) != SPAN_ENTRY) {
 		return false;
 	}
 
-	if (span_entry.timestamp == PMEMSTREAM_INVALID_TIMESTAMP) {
+	if (span_timestamped.timestamp == PMEMSTREAM_INVALID_TIMESTAMP) {
 		return false;
 	}
 
-	if (span_entry.timestamp <= max_valid_timestamp) {
+	if (span_timestamped.timestamp <= max_valid_timestamp) {
 		return true;
 	}
 

--- a/src/span.c
+++ b/src/span.c
@@ -51,16 +51,16 @@ void span_base_atomic_store(struct span_base *dst, struct span_base base)
 	atomic_store_release(&dst->size_and_type, base.size_and_type);
 }
 
-void span_entry_atomic_store(struct span_entry *dst, struct span_entry entry)
+void span_timestamped_base_atomic_store(struct span_timestamped_base *dst, struct span_timestamped_base entry)
 {
 	/* Store timestamp first because it's only valid for ENTRY span type. */
 	atomic_store_relaxed(&dst->timestamp, entry.timestamp);
 	atomic_store_release(&dst->span_base.size_and_type, entry.span_base.size_and_type);
 }
 
-struct span_entry span_entry_atomic_load(const struct span_entry *entry_ptr)
+struct span_timestamped_base span_timestamped_base_atomic_load(const struct span_timestamped_base *entry_ptr)
 {
-	struct span_entry entry;
+	struct span_timestamped_base entry;
 	atomic_load_acquire(&entry_ptr->span_base.size_and_type, &entry.span_base.size_and_type);
 	atomic_load_relaxed(&entry_ptr->timestamp, &entry.timestamp);
 	return entry;

--- a/src/span.h
+++ b/src/span.h
@@ -49,9 +49,13 @@ struct span_region {
 static_assert(sizeof(struct span_region) == CACHELINE_SIZE,
 	      "size of struct span_region must be equal to CACHELINE_SIZE");
 
-struct span_entry {
+struct span_timestamped_base {
 	struct span_base span_base;
 	uint64_t timestamp;
+};
+
+struct span_entry {
+	struct span_timestamped_base span_timestamped_base;
 	uint64_t data[];
 };
 
@@ -73,8 +77,8 @@ enum span_type span_get_type(const struct span_base *span);
 
 void span_base_atomic_store(struct span_base *dst, struct span_base base);
 
-void span_entry_atomic_store(struct span_entry *dst, struct span_entry entry);
-struct span_entry span_entry_atomic_load(const struct span_entry *entry);
+void span_timestamped_base_atomic_store(struct span_timestamped_base *dst, struct span_timestamped_base entry);
+struct span_timestamped_base span_timestamped_base_atomic_load(const struct span_timestamped_base *entry);
 
 #ifdef __cplusplus
 } /* end extern "C" */

--- a/tests/common/stream_span_helpers.cpp
+++ b/tests/common/stream_span_helpers.cpp
@@ -46,7 +46,7 @@ std::string span_to_str(const struct span_base *base)
 	std::string span_str = "type: " + span_type_names[type] + ", data size: " + std::to_string(span_get_size(base));
 	if (type == SPAN_ENTRY) {
 		auto entry = (const struct span_entry *)base;
-		span_str += ", timestamp: " + std::to_string(entry->timestamp);
+		span_str += ", timestamp: " + std::to_string(entry->span_timestamped_base.timestamp);
 	}
 	return span_str;
 }

--- a/tests/integrity/append_break.cpp
+++ b/tests/integrity/append_break.cpp
@@ -120,14 +120,14 @@ static void test(std::string mode)
 
 		/* in the 1. region there should be 4 entry spans (incl. broken one) + potentially 1 empty span */
 		UT_ASSERT(regions[0].sub_spans.size() >= 4);
-		auto broken_entry_in_r1 = (struct span_entry *)span_offset_to_span_ptr(&s.sut.c_ptr()->data,
-										       regions[0].sub_spans[3].offset);
+		auto broken_entry_in_r1 = (struct span_timestamped_base *)span_offset_to_span_ptr(
+			&s.sut.c_ptr()->data, regions[0].sub_spans[3].offset);
 		UT_ASSERT(span_get_type(&broken_entry_in_r1->span_base) == SPAN_ENTRY);
 
 		/* in the 2. region there have to be 1 entry + 1 empty span (we clear out 1 span after an append) */
 		UT_ASSERTeq(regions[1].sub_spans.size(), 2);
-		auto new_entry_in_r2 = (struct span_entry *)span_offset_to_span_ptr(&s.sut.c_ptr()->data,
-										    regions[1].sub_spans[0].offset);
+		auto new_entry_in_r2 = (struct span_timestamped_base *)span_offset_to_span_ptr(
+			&s.sut.c_ptr()->data, regions[1].sub_spans[0].offset);
 		UT_ASSERT(span_get_type(&new_entry_in_r2->span_base) == SPAN_ENTRY);
 		UT_ASSERTeq(broken_entry_in_r1->timestamp, new_entry_in_r2->timestamp);
 
@@ -157,8 +157,8 @@ static void test(std::string mode)
 
 		/* 1. region: 4 entry spans + 1 empty span (+ possible trash) */
 		UT_ASSERT(regions[0].sub_spans.size() >= 5);
-		auto new_entry_in_r1 = (struct span_entry *)span_offset_to_span_ptr(&s.sut.c_ptr()->data,
-										    regions[0].sub_spans[3].offset);
+		auto new_entry_in_r1 = (struct span_timestamped_base *)span_offset_to_span_ptr(
+			&s.sut.c_ptr()->data, regions[0].sub_spans[3].offset);
 		UT_ASSERT(span_get_type(&new_entry_in_r1->span_base) == SPAN_ENTRY);
 		auto next_empty_in_r1 = (struct span_base *)span_offset_to_span_ptr(&s.sut.c_ptr()->data,
 										    regions[0].sub_spans[4].offset);
@@ -166,8 +166,8 @@ static void test(std::string mode)
 
 		/* 2. region: 1 entry span + 1 empty span */
 		UT_ASSERTeq(regions[1].sub_spans.size(), 2);
-		new_entry_in_r2 = (struct span_entry *)span_offset_to_span_ptr(&s.sut.c_ptr()->data,
-									       regions[1].sub_spans[0].offset);
+		new_entry_in_r2 = (struct span_timestamped_base *)span_offset_to_span_ptr(
+			&s.sut.c_ptr()->data, regions[1].sub_spans[0].offset);
 		UT_ASSERT(span_get_type(&new_entry_in_r2->span_base) == SPAN_ENTRY);
 		auto next_empty_in_r2 = (struct span_base *)span_offset_to_span_ptr(&s.sut.c_ptr()->data,
 										    regions[1].sub_spans[1].offset);


### PR DESCRIPTION
There are 2 ways of mitigating ABI warning.
The first one is to avoid copying structures with a flexible array member
by using pointers. The second is to change structures declarations, e.g.:

struct span_timestamped_base {
    struct span_base span_base;
    uint64_t timestamp;
};

struct span_entry {
    struct span_timestamped_base span_base;
    uint64_t data[];
};

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemstream/247)
<!-- Reviewable:end -->
