### PR TITLE
Revert "docker: use PMDK with fix for ndctl header"

### DIFF
--- a/utils/docker/images/fedora-34.Dockerfile
+++ b/utils/docker/images/fedora-34.Dockerfile
@@ -14,8 +14,6 @@ MAINTAINER igor.chorazewicz@intel.com
 USER root
 
 # Install all PMDK packages
-# Use non-released ("custom") version with the fix for proper ndctl header include
-ENV PMDK_VERSION bbd93c8c4c3ca8bc4d1136ad30b3bc15fa78919a
 RUN /opt/install-pmdk.sh /opt/pmdk/
 
 # Install rapidcheck

--- a/utils/docker/images/fedora-35.Dockerfile
+++ b/utils/docker/images/fedora-35.Dockerfile
@@ -14,8 +14,6 @@ MAINTAINER igor.chorazewicz@intel.com
 USER root
 
 # Install all PMDK packages
-# Use non-released ("custom") version with the fix for proper ndctl header include
-ENV PMDK_VERSION bbd93c8c4c3ca8bc4d1136ad30b3bc15fa78919a
 RUN /opt/install-pmdk.sh /opt/pmdk/
 
 # Install rapidcheck


### PR DESCRIPTION
This reverts commit 5c3302f996346f3261abe110906ac1b4dccf2108.

The custom version is no longer required, since dev-utils-kit already
uses the latest PMDK's release - 1.12.0 (which contains required fix).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemstream/258)
<!-- Reviewable:end -->
