### PR TITLE
[tests] Use Valgrind macro to indicate that checker is used

### DIFF
--- a/tests/common/valgrind_internal.c
+++ b/tests/common/valgrind_internal.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 
 #include "valgrind_internal.h"
+#include <valgrind.h>
 
 unsigned On_valgrind = 0;
 unsigned On_pmemcheck = 0;
@@ -22,5 +23,5 @@ void set_valgrind_internals(void)
 	else if (getenv("PMEMSTREAM_TRACER_DRD"))
 		On_drd = 1;
 
-	On_valgrind = On_pmemcheck || On_memcheck || On_helgrind || On_drd;
+	On_valgrind = On_pmemcheck || On_memcheck || On_helgrind || On_drd || RUNNING_ON_VALGRIND;
 }


### PR DESCRIPTION
This commit involves `RUNNING_ON_VALGRIND` macro to detect that
tests are executed under Valgrind.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemstream/266)
<!-- Reviewable:end -->
