### PR TITLE
[tests] Allow to reuse config object inside run_test function

### DIFF
--- a/tests/common/unittest.hpp
+++ b/tests/common/unittest.hpp
@@ -88,7 +88,7 @@ static const test_config_type &get_test_config()
 	return test_config;
 }
 
-static inline int run_test(test_config_type config, std::function<void()> test)
+static inline int run_test(test_config_type &config, std::function<void()> test)
 {
 	test_register_sighandlers();
 	set_valgrind_internals();
@@ -121,7 +121,8 @@ static inline int run_test(test_config_type config, std::function<void()> test)
 
 static inline int run_test(std::function<void()> test)
 {
-	return run_test({}, test);
+	test_config_type default_config;
+	return run_test(default_config, test);
 }
 
 /* Helper structure for verifying return values from function.


### PR DESCRIPTION
Config object passed into the run_test function will be modified by
that function accordingly to some requirements.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemstream/267)
<!-- Reviewable:end -->
