### PR TITLE
[helpers] Use config value for multi-region stream generator

### DIFF
--- a/tests/common/rapidcheck_helpers.hpp
+++ b/tests/common/rapidcheck_helpers.hpp
@@ -11,6 +11,7 @@
 
 #include "span.h"
 #include "stream_helpers.hpp"
+#include "unittest.hpp"
 
 /*
  * Definition of models and commands for stateful testing.
@@ -149,7 +150,7 @@ struct Arbitrary<pmemstream_with_multi_empty_regions> {
 	{
 		return gen::noShrink(gen::construct<pmemstream_with_multi_empty_regions>(
 			gen::arbitrary<pmemstream_test_base>(),
-			gen::inRange<size_t>(1, TEST_DEFAULT_REGION_MULTI_MAX_COUNT)));
+			gen::inRange<size_t>(1, get_test_config().regions_count)));
 	}
 };
 


### PR DESCRIPTION
Use config's `regions_count` value instead of the default value.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemstream/268)
<!-- Reviewable:end -->
